### PR TITLE
[codex] 增加软著生成与代码材料准备流程

### DIFF
--- a/analytics/dashboard/public/src/pages/traffic.js
+++ b/analytics/dashboard/public/src/pages/traffic.js
@@ -11,6 +11,8 @@ const pageLabels = {
   'technical-plan/content-edit': '技术方案 - 生成正文',
   'technical-plan/expand': '技术方案 - 扩写改写',
   'business-bid': '商务标',
+  'code-generation': '代码生成',
+  'software-copyright': '软著生成',
   'knowledge-base': '知识库',
   'knowledge-base/library': '知识库 - 文档列表',
   'knowledge-base/viewer/items': '知识库 - 知识条目',

--- a/client/electron/ipc/codeGenerationIpc.cjs
+++ b/client/electron/ipc/codeGenerationIpc.cjs
@@ -1,0 +1,13 @@
+const { ipcMain } = require('electron');
+
+function registerCodeGenerationIpc({ codeGenerationService }) {
+  ipcMain.handle('code-generation:load-state', () => codeGenerationService.loadState());
+  ipcMain.handle('code-generation:select-project', () => codeGenerationService.selectProject());
+  ipcMain.handle('code-generation:update-selection', (_event, payload) => codeGenerationService.updateSelection(payload));
+  ipcMain.handle('code-generation:confirm-selection', () => codeGenerationService.confirmSelection());
+  ipcMain.handle('code-generation:clear', () => codeGenerationService.clear());
+}
+
+module.exports = {
+  registerCodeGenerationIpc,
+};

--- a/client/electron/ipc/index.cjs
+++ b/client/electron/ipc/index.cjs
@@ -1,14 +1,17 @@
 const { ipcMain, shell } = require('electron');
 const { registerAiIpc } = require('./aiIpc.cjs');
+const { registerCodeGenerationIpc } = require('./codeGenerationIpc.cjs');
 const { registerConfigIpc } = require('./configIpc.cjs');
 const { registerDuplicateCheckIpc } = require('./duplicateCheckIpc.cjs');
 const { registerExportIpc } = require('./exportIpc.cjs');
 const { registerFileIpc } = require('./fileIpc.cjs');
 const { registerKnowledgeBaseIpc } = require('./knowledgeBaseIpc.cjs');
 const { registerRejectionCheckIpc } = require('./rejectionCheckIpc.cjs');
+const { registerSoftwareCopyrightIpc } = require('./softwareCopyrightIpc.cjs');
 const { registerTaskIpc } = require('./taskIpc.cjs');
 const { registerTechnicalPlanIpc } = require('./technicalPlanIpc.cjs');
 const { createAiService } = require('../services/aiService.cjs');
+const { createCodeGenerationService } = require('../services/codeGenerationService.cjs');
 const { createConfigStore } = require('../services/configStore.cjs');
 const { createDuplicateCheckService } = require('../services/duplicateCheckService.cjs');
 const { createDuplicateCheckStore } = require('../services/duplicateCheckStore.cjs');
@@ -17,6 +20,7 @@ const { createFileService } = require('../services/fileService.cjs');
 const { createKnowledgeBaseService } = require('../services/knowledgeBaseService.cjs');
 const { createKnowledgeBaseStore } = require('../services/knowledgeBaseStore.cjs');
 const { createRejectionCheckStore } = require('../services/rejectionCheckStore.cjs');
+const { createSoftwareCopyrightService } = require('../services/softwareCopyrightService.cjs');
 const { createSqliteDatabase } = require('../services/sqliteDatabase.cjs');
 const { createTaskService } = require('../services/taskService.cjs');
 const { createTechnicalPlanStore } = require('../services/technicalPlanStore.cjs');
@@ -168,11 +172,14 @@ function registerIpcHandlers({ app, mainWindow, checkAndDownloadUpdate, triggerU
   const aiService = createAiService({ app, configStore });
   const fileService = createFileService({ app, configStore });
   const exportService = createExportService({ configStore });
+  const codeGenerationService = createCodeGenerationService({ app });
 
   registerConfigIpc({ configStore, aiService });
   registerAiIpc({ aiService });
   registerFileIpc({ fileService });
   registerExportIpc({ exportService });
+  registerCodeGenerationIpc({ codeGenerationService });
+  registerSoftwareCopyrightIpc({ softwareCopyrightService: createSoftwareCopyrightService({ app, aiService, configStore, codeGenerationService }) });
 
   try {
     const sqliteDatabase = createSqliteDatabase(app);

--- a/client/electron/ipc/softwareCopyrightIpc.cjs
+++ b/client/electron/ipc/softwareCopyrightIpc.cjs
@@ -1,0 +1,31 @@
+const { ipcMain } = require('electron');
+
+function registerSoftwareCopyrightIpc({ softwareCopyrightService }) {
+  ipcMain.handle('software-copyright:load-state', () => softwareCopyrightService.loadState());
+  ipcMain.handle('software-copyright:select-project', () => softwareCopyrightService.selectProject());
+  ipcMain.handle('software-copyright:save-fields', (_event, fields) => softwareCopyrightService.saveFields(fields));
+  ipcMain.handle('software-copyright:save-options', (_event, options) => softwareCopyrightService.saveOptions(options));
+  ipcMain.handle('software-copyright:read-draft', (_event, draftKey) => softwareCopyrightService.readDraft(draftKey));
+  ipcMain.handle('software-copyright:read-code-manifest', () => softwareCopyrightService.readCodeManifest());
+  ipcMain.handle('software-copyright:regenerate-code-material', (_event, payload) => softwareCopyrightService.regenerateCodeMaterial(payload));
+  ipcMain.handle('software-copyright:save-draft', (_event, payload) => softwareCopyrightService.saveDraft(payload));
+  ipcMain.handle('software-copyright:validate-draft', () => softwareCopyrightService.validateDraft());
+  ipcMain.handle('software-copyright:start-generation', (event, payload) => {
+    softwareCopyrightService.subscribe(event.sender);
+    return softwareCopyrightService.startGeneration(payload);
+  });
+  ipcMain.handle('software-copyright:confirm-draft', () => softwareCopyrightService.confirmDraft());
+  ipcMain.handle('software-copyright:export-final', (event, payload) => {
+    softwareCopyrightService.subscribe(event.sender);
+    return softwareCopyrightService.exportFinal(payload);
+  });
+  ipcMain.handle('software-copyright:clear', () => softwareCopyrightService.clear());
+  ipcMain.handle('software-copyright:open-output-dir', () => softwareCopyrightService.openOutputDir());
+  ipcMain.on('software-copyright:subscribe', (event) => {
+    softwareCopyrightService.subscribe(event.sender);
+  });
+}
+
+module.exports = {
+  registerSoftwareCopyrightIpc,
+};

--- a/client/electron/preload.cjs
+++ b/client/electron/preload.cjs
@@ -38,6 +38,13 @@ const bridge = {
   file: {
     selectDuplicateCheckFiles: (options) => ipcRenderer.invoke('file:select-duplicate-check-files', options),
   },
+  codeGeneration: {
+    loadState: () => ipcRenderer.invoke('code-generation:load-state'),
+    selectProject: () => ipcRenderer.invoke('code-generation:select-project'),
+    updateSelection: (payload) => ipcRenderer.invoke('code-generation:update-selection', payload),
+    confirmSelection: () => ipcRenderer.invoke('code-generation:confirm-selection'),
+    clear: () => ipcRenderer.invoke('code-generation:clear'),
+  },
   knowledgeBase: {
     getMigrationStatus: () => ipcRenderer.invoke('knowledge-base:get-migration-status'),
     migrateLegacy: () => ipcRenderer.invoke('knowledge-base:migrate-legacy'),
@@ -84,6 +91,28 @@ const bridge = {
     saveUiState: (payload) => ipcRenderer.invoke('rejection-check:save-ui-state', payload),
     updateState: (partial) => ipcRenderer.invoke('rejection-check:update-state', partial),
     clear: () => ipcRenderer.invoke('rejection-check:clear'),
+  },
+  softwareCopyright: {
+    loadState: () => ipcRenderer.invoke('software-copyright:load-state'),
+    selectProject: () => ipcRenderer.invoke('software-copyright:select-project'),
+    saveFields: (fields) => ipcRenderer.invoke('software-copyright:save-fields', fields),
+    saveOptions: (options) => ipcRenderer.invoke('software-copyright:save-options', options),
+    readDraft: (draftKey) => ipcRenderer.invoke('software-copyright:read-draft', draftKey),
+    readCodeManifest: () => ipcRenderer.invoke('software-copyright:read-code-manifest'),
+    regenerateCodeMaterial: (payload) => ipcRenderer.invoke('software-copyright:regenerate-code-material', payload),
+    saveDraft: (payload) => ipcRenderer.invoke('software-copyright:save-draft', payload),
+    validateDraft: () => ipcRenderer.invoke('software-copyright:validate-draft'),
+    startGeneration: (payload) => ipcRenderer.invoke('software-copyright:start-generation', payload),
+    confirmDraft: () => ipcRenderer.invoke('software-copyright:confirm-draft'),
+    exportFinal: (payload) => ipcRenderer.invoke('software-copyright:export-final', payload),
+    clear: () => ipcRenderer.invoke('software-copyright:clear'),
+    openOutputDir: () => ipcRenderer.invoke('software-copyright:open-output-dir'),
+    onEvent: (callback) => {
+      ipcRenderer.send('software-copyright:subscribe');
+      const listener = (_event, payload) => callback(payload);
+      ipcRenderer.on('software-copyright:event', listener);
+      return () => ipcRenderer.removeListener('software-copyright:event', listener);
+    },
   },
   tasks: {
     startBidAnalysis: (payload) => ipcRenderer.invoke('tasks:start-bid-analysis', payload),

--- a/client/electron/services/codeGenerationService.cjs
+++ b/client/electron/services/codeGenerationService.cjs
@@ -1,0 +1,253 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { dialog } = require('electron');
+const { getCodeGenerationDir } = require('../utils/paths.cjs');
+
+const CODE_EXTS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.css', '.scss', '.less', '.html', '.vue', '.svelte', '.astro', '.py', '.java', '.go', '.rs', '.cs', '.sql']);
+const SKIP_DIRS = new Set(['.git', '.hg', '.svn', '.idea', '.vscode', 'node_modules', 'dist', 'build', 'release', 'coverage', 'archive', '软件著作权申请资料']);
+const SKIP_FILES = new Set(['package-lock.json', 'pnpm-lock.yaml', 'yarn.lock', 'bun.lock', 'tsconfig.tsbuildinfo']);
+const TARGET_LINES = 60 * 50;
+
+const initialState = {
+  project: null,
+  analysis: null,
+  selectedPaths: [],
+  confirmed: false,
+  confirmedAt: '',
+  updated_at: '',
+};
+
+function now() {
+  return new Date().toISOString();
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function readJson(filePath, fallback) {
+  if (!fs.existsSync(filePath)) return fallback;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson(filePath, data) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+function readText(filePath, limit) {
+  const buffer = fs.readFileSync(filePath);
+  const data = limit ? buffer.subarray(0, limit) : buffer;
+  for (const encoding of ['utf-8', 'utf8', 'gb18030', 'latin1']) {
+    try {
+      return data.toString(encoding);
+    } catch {
+      // Try next encoding.
+    }
+  }
+  return data.toString('utf-8');
+}
+
+function rel(filePath, root) {
+  return path.relative(root, filePath).split(path.sep).join('/');
+}
+
+function isSkipped(filePath) {
+  const parts = filePath.split(path.sep);
+  if (parts.some((part) => SKIP_DIRS.has(part))) return true;
+  const name = path.basename(filePath);
+  if (SKIP_FILES.has(name)) return true;
+  if (name.endsWith('.map') || name.endsWith('.min.js') || name.endsWith('.min.css')) return true;
+  return false;
+}
+
+function walkFiles(root, results = []) {
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const filePath = path.join(root, entry.name);
+    if (isSkipped(filePath)) continue;
+    if (entry.isDirectory()) {
+      walkFiles(filePath, results);
+    } else if (entry.isFile() && CODE_EXTS.has(path.extname(entry.name).toLowerCase())) {
+      const stat = fs.statSync(filePath);
+      if (stat.size > 0 && stat.size <= 900_000) {
+        results.push({ filePath, size: stat.size });
+      }
+    }
+  }
+  return results;
+}
+
+function classifyFile(relativePath) {
+  const r = relativePath.toLowerCase();
+  const name = path.basename(r);
+  if (['main.ts', 'main.tsx', 'main.js', 'main.jsx', 'app.tsx', 'app.vue', 'index.tsx', 'index.jsx'].includes(name)) return '入口';
+  if (r.includes('/router') || r.includes('/routes') || name.includes('router') || name.includes('route')) return '路由';
+  if (r.includes('/pages/') || r.includes('/views/') || r.includes('/screens/') || r.includes('/app/')) return '页面';
+  if (r.includes('/services/') || r.includes('/api/') || r.includes('/ipc/') || r.includes('/handlers/')) return '业务服务';
+  if (r.includes('/components/')) return '组件';
+  if (r.includes('/store') || r.includes('/stores') || r.includes('/redux')) return '状态数据';
+  if (r.includes('/utils/') || r.includes('/shared/') || r.includes('/hooks/')) return '通用能力';
+  if (['.css', '.scss', '.less'].includes(path.extname(r))) return '样式';
+  return '源码';
+}
+
+function categoryPriority(category) {
+  const index = ['入口', '路由', '页面', '业务服务', '状态数据', '组件', '通用能力', '源码', '样式'].indexOf(category);
+  return index >= 0 ? index : 99;
+}
+
+function readPackage(projectDir) {
+  const packagePath = ['package.json', 'client/package.json', 'frontend/package.json', 'web/package.json']
+    .map((name) => path.join(projectDir, name))
+    .find((candidate) => fs.existsSync(candidate));
+  return packagePath ? readJson(packagePath, {}) : {};
+}
+
+function analyzeProject(projectDir) {
+  const packageJson = readPackage(projectDir);
+  const files = walkFiles(projectDir).map((item) => {
+    const relativePath = rel(item.filePath, projectDir);
+    const text = readText(item.filePath, 400_000);
+    const lineCount = text.split(/\r?\n/).length;
+    return {
+      path: relativePath,
+      extension: path.extname(item.filePath).toLowerCase(),
+      size: item.size,
+      line_count: lineCount,
+      category: classifyFile(relativePath),
+    };
+  });
+
+  files.sort((a, b) => categoryPriority(a.category) - categoryPriority(b.category) || b.line_count - a.line_count);
+  const dependencies = { ...(packageJson.dependencies || {}), ...(packageJson.devDependencies || {}) };
+  const frameworks = Object.keys(dependencies).filter((name) => ['react', 'vue', 'vite', 'electron', 'next', 'typescript'].some((key) => name.toLowerCase().includes(key)));
+  const lineCount = files.reduce((sum, item) => sum + item.line_count, 0);
+  const languages = Array.from(new Set(files.map((item) => item.extension.replace('.', '')).filter(Boolean))).slice(0, 8);
+
+  return {
+    projectRoot: projectDir,
+    projectName: path.basename(projectDir),
+    packageName: packageJson.name || '',
+    packageVersion: packageJson.version || '',
+    frameworks,
+    languages,
+    fileCount: files.length,
+    lineCount,
+    candidates: files.slice(0, 220),
+  };
+}
+
+function createDefaultSelectedPaths(analysis) {
+  const selected = [];
+  let lines = 0;
+  for (const item of analysis.candidates || []) {
+    if (item.category === '样式' && lines < TARGET_LINES) continue;
+    selected.push(item.path);
+    lines += item.line_count + 2;
+    if (lines >= TARGET_LINES) break;
+  }
+  return selected.length ? selected : (analysis.candidates || []).slice(0, 20).map((item) => item.path);
+}
+
+function selectionSummary(analysis, selectedPaths) {
+  const selectedSet = new Set(selectedPaths || []);
+  const selectedFiles = (analysis?.candidates || []).filter((item) => selectedSet.has(item.path));
+  const selectedLineCount = selectedFiles.reduce((sum, item) => sum + item.line_count + 2, 0);
+  return {
+    selectedCount: selectedFiles.length,
+    selectedLineCount,
+    estimatedPages: Math.ceil(selectedLineCount / 50),
+    selectedFiles,
+  };
+}
+
+function createCodeGenerationService({ app }) {
+  const rootDir = getCodeGenerationDir(app);
+  const statePath = path.join(rootDir, 'state.json');
+
+  function loadState() {
+    ensureDir(rootDir);
+    const saved = readJson(statePath, null);
+    const next = { ...initialState, ...(saved || {}) };
+    return {
+      ...next,
+      summary: selectionSummary(next.analysis, next.selectedPaths),
+    };
+  }
+
+  function saveState(partial) {
+    const previous = loadState();
+    const next = {
+      ...previous,
+      ...partial,
+      updated_at: now(),
+    };
+    delete next.summary;
+    writeJson(statePath, next);
+    return loadState();
+  }
+
+  return {
+    loadState,
+    async selectProject() {
+      const result = await dialog.showOpenDialog({ properties: ['openDirectory'], title: '选择需要整理软著代码素材的项目目录' });
+      if (result.canceled || !result.filePaths?.[0]) {
+        return { success: false, message: '已取消选择', state: loadState() };
+      }
+      const projectDir = result.filePaths[0];
+      const analysis = analyzeProject(projectDir);
+      const selectedPaths = createDefaultSelectedPaths(analysis);
+      const state = saveState({
+        project: { path: projectDir, name: path.basename(projectDir) },
+        analysis,
+        selectedPaths,
+        confirmed: false,
+        confirmedAt: '',
+      });
+      return { success: true, state };
+    },
+    updateSelection(payload = {}) {
+      const current = loadState();
+      const selectedPaths = Array.isArray(payload.selectedPaths) ? payload.selectedPaths.map(String) : current.selectedPaths;
+      return saveState({ selectedPaths, confirmed: false, confirmedAt: '' });
+    },
+    confirmSelection() {
+      const current = loadState();
+      if (!current.project || !current.analysis) {
+        throw new Error('请先选择项目并扫描源码');
+      }
+      if (!current.selectedPaths?.length) {
+        throw new Error('请至少选择一个源码文件');
+      }
+      return saveState({ confirmed: true, confirmedAt: now() });
+    },
+    clear() {
+      const next = { ...initialState, updated_at: now() };
+      writeJson(statePath, next);
+      return { success: true, state: loadState() };
+    },
+    getConfirmedMaterials() {
+      const state = loadState();
+      if (!state.confirmed || !state.project || !state.analysis || !state.selectedPaths?.length) {
+        return null;
+      }
+      const selectedSet = new Set(state.selectedPaths);
+      return {
+        project: state.project,
+        analysis: state.analysis,
+        selectedFiles: (state.analysis.candidates || []).filter((item) => selectedSet.has(item.path)),
+        confirmedAt: state.confirmedAt,
+        summary: state.summary,
+      };
+    },
+  };
+}
+
+module.exports = {
+  createCodeGenerationService,
+};

--- a/client/electron/services/softwareCopyrightPrompts.cjs
+++ b/client/electron/services/softwareCopyrightPrompts.cjs
@@ -1,0 +1,91 @@
+function buildAnalysisEvidence(analysis) {
+  const candidateLines = (analysis.candidates || [])
+    .slice(0, 45)
+    .map((item) => `- ${item.path}（${item.category}，${item.line_count} 行）`)
+    .join('\n');
+  const groupedCandidates = ['入口', '路由', '页面', '业务服务', '组件', '状态数据', '通用能力']
+    .map((category) => {
+      const files = (analysis.candidates || [])
+        .filter((item) => item.category === category)
+        .slice(0, 12)
+        .map((item) => item.path)
+        .join('、');
+      return files ? `${category}：${files}` : '';
+    })
+    .filter(Boolean)
+    .join('\n');
+  return [
+    `项目名称：${analysis.projectName}`,
+    `包名：${analysis.packageName || '无'}`,
+    `版本：${analysis.packageVersion || '无'}`,
+    `技术栈：${analysis.frameworks.join('、') || '未识别'}`,
+    `编程语言：${analysis.languages.join('、') || '未识别'}`,
+    `源码文件数：${analysis.fileCount}`,
+    `源码总行数：${analysis.lineCount}`,
+    analysis.readmeExcerpt ? `README 摘要：\n${analysis.readmeExcerpt}` : '',
+    groupedCandidates ? `按类型归纳的源码证据：\n${groupedCandidates}` : '',
+    `主要源码证据：\n${candidateLines}`,
+  ].filter(Boolean).join('\n\n');
+}
+
+function buildBusinessContextMessages({ analysis, fields }) {
+  return [
+    {
+      role: 'system',
+      content: '你是中文软件著作权材料助手。只根据项目证据生成真实、克制、可核对的业务理解 JSON，不编造项目不存在的功能。',
+    },
+    {
+      role: 'user',
+      content: [
+        '请根据以下项目证据生成软件著作权申请材料用的业务理解 JSON。',
+        '字段包括 product_positioning、industry、target_users、core_value、business_features、operation_flow、main_functions、technical_characteristics、manual_modules。',
+        'manual_modules 每项包含 title、purpose、entry、visible_elements、operation_steps、validation_rules、feedback、screenshot、source_files。',
+        '要求：',
+        '1. 只写源码证据或用户已确认字段能支撑的软件功能，不编造登录、支付、消息推送、权限审批等证据中不存在的模块。',
+        '2. business_features 使用用户可感知的业务功能名称，避免“React 组件”“IPC 服务”等技术实现名称。',
+        '3. manual_modules 优先来自页面、路由、入口和业务服务文件；每项 source_files 写 1-3 个对应源码路径。',
+        '4. operation_flow 写普通用户视角的操作流程，不写代码流程、接口调用或数据库细节。',
+        '5. technical_characteristics 保持软著登记口径，按项目证据描述软件形态、数据处理和导出等能力，不展开源码实现。',
+        '6. 不要把单一能力泛化成更宽能力：例如证据只支持 PDF 导出时，只写 PDF 导出，不写“多格式导出”；只有源码或用户字段明确支持多个格式时才写“多格式”。',
+        `用户已确认/填写字段：${JSON.stringify(fields)}`,
+        buildAnalysisEvidence(analysis),
+      ].join('\n\n'),
+    },
+  ];
+}
+
+function buildManualMarkdownMessages({ fields, business, modules }) {
+  return [
+    {
+      role: 'system',
+      content: '你是中文软件著作权操作手册撰写助手。输出 Markdown。语言面向普通用户，不写代码实现，不写技术框架，不使用营销套话。',
+    },
+    {
+      role: 'user',
+      content: [
+        `请为“${fields.softwareName} ${fields.version}”生成软著操作手册草稿。`,
+        '总要求：一级章节使用“一、二、三”中文序号；包含相关文档、说明、功能特点、系统要求、核心功能操作、常见问题解答、术语表；每个核心模块保留可见截图预留位。',
+        '写作要求：',
+        '1. 面向普通软件用户写操作手册，不出现源码、函数名、类名、IPC、数据库表、依赖包等实现细节。',
+        '2. 核心功能章节必须来自“核心模块”，每个模块写入口、页面可见内容、操作步骤、校验提示、完成反馈。',
+        '3. 操作步骤用连贯自然语言，避免空泛的“进行相关操作”“完成业务处理”。',
+        '4. 不编造证据中不存在的功能；信息不足时使用“页面提示”“对应菜单”这类稳妥表述。',
+        '5. 截图预留位统一写成“【截图预留：xxx】”，不要生成图片链接。',
+        '6. 不要扩大功能范围：例如业务理解或用户字段只写 PDF 导出时，手册也只能写 PDF 导出，不写“多格式导出”。',
+        '7. 文风应像正式软件著作权操作手册，克制、具体、可核对，不写营销口号。',
+        `业务理解：${JSON.stringify(business)}`,
+        `核心模块：${JSON.stringify(modules)}`,
+      ].join('\n\n'),
+    },
+  ];
+}
+
+function buildManualIllustrationPrompt(fields) {
+  return `为中文软件著作权操作手册生成一张干净的产品流程示意图，软件名称：${fields.softwareName}。画面包含软件界面、资料输入、处理进度、结果导出，不出现真实品牌标识，不包含敏感信息。`;
+}
+
+module.exports = {
+  buildBusinessContextMessages,
+  buildManualIllustrationPrompt,
+  buildManualMarkdownMessages,
+};

--- a/client/electron/services/softwareCopyrightService.cjs
+++ b/client/electron/services/softwareCopyrightService.cjs
@@ -1,0 +1,1726 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { dialog, shell } = require('electron');
+const {
+  AlignmentType,
+  BorderStyle,
+  Document,
+  Footer,
+  Header,
+  HeadingLevel,
+  ImageRun,
+  Packer,
+  PageNumber,
+  PageOrientation,
+  Paragraph,
+  Table,
+  TableCell,
+  TableRow,
+  TextRun,
+  WidthType,
+} = require('docx');
+const { getSoftwareCopyrightDir } = require('../utils/paths.cjs');
+const {
+  buildBusinessContextMessages,
+  buildManualIllustrationPrompt,
+  buildManualMarkdownMessages,
+} = require('./softwareCopyrightPrompts.cjs');
+
+const CODE_EXTS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.css', '.scss', '.less', '.html', '.vue', '.svelte', '.astro', '.py', '.java', '.go', '.rs', '.cs', '.sql']);
+const SKIP_DIRS = new Set(['.git', '.hg', '.svn', '.idea', '.vscode', 'node_modules', 'dist', 'build', 'release', 'coverage', 'archive', '软件著作权申请资料']);
+const SKIP_FILES = new Set(['package-lock.json', 'pnpm-lock.yaml', 'yarn.lock', 'bun.lock', 'tsconfig.tsbuildinfo']);
+const LINES_PER_PAGE = 24;
+const SPLIT_PAGES = 60;
+const CORE_CODE_CATEGORIES = ['入口', '路由', '页面', '业务服务', '状态数据', '组件', '通用能力'];
+const CATEGORY_SELECTION_WEIGHT = {
+  入口: 120,
+  路由: 110,
+  页面: 105,
+  业务服务: 100,
+  状态数据: 88,
+  组件: 78,
+  通用能力: 68,
+  源码: 46,
+  样式: 8,
+};
+const SOURCE_EXT_WEIGHT = {
+  '.ts': 24,
+  '.tsx': 24,
+  '.js': 18,
+  '.jsx': 18,
+  '.vue': 18,
+  '.svelte': 18,
+  '.astro': 18,
+  '.py': 16,
+  '.java': 16,
+  '.go': 16,
+  '.rs': 16,
+  '.cs': 16,
+  '.sql': 10,
+  '.html': 8,
+  '.css': 2,
+  '.scss': 2,
+  '.less': 2,
+};
+const A4_PAGE_SIZE = {
+  width: 11906,
+  height: 16838,
+  orientation: PageOrientation.PORTRAIT,
+};
+const STANDARD_PAGE_MARGIN = {
+  top: 1417,
+  right: 1417,
+  bottom: 1417,
+  left: 1417,
+  header: 567,
+  footer: 567,
+};
+
+const initialFields = {
+  softwareName: '',
+  shortName: '',
+  version: 'V1.0',
+  category: '应用软件',
+  developmentCompletedDate: '',
+  developmentMode: '单独开发',
+  softwareDescription: '原创',
+  publishStatus: '未发表',
+  firstPublishDate: '',
+  copyrightOwner: '',
+  rightsScope: '全部权利',
+  rightsAcquisition: '原始取得',
+  developmentHardware: '',
+  runningHardware: '',
+  developmentOs: '',
+  developmentTools: '',
+  runningPlatform: '',
+  runtimeSupport: '',
+  programmingLanguage: '',
+  sourceLineCount: '',
+  developmentPurpose: '',
+  industry: '',
+  mainFunctions: '',
+  technicalFeatures: '',
+  pageCount: '',
+};
+
+const initialState = {
+  step: 'setup',
+  project: null,
+  analysis: null,
+  fields: initialFields,
+  options: {
+    sourceMode: 'project',
+    screenshotMode: 'skip',
+    useAiImages: false,
+    exportItems: {
+      application: true,
+      manual: true,
+      code: true,
+      report: true,
+    },
+    codeExcludedPaths: [],
+    codeIncludedPaths: [],
+  },
+  imageModel: {
+    available: false,
+    status: 'untested',
+    message: '尚未检查生图模型',
+  },
+  task: undefined,
+  drafts: {},
+  draftConfirmed: false,
+  draftConfirmedAt: '',
+  draftDir: '',
+  outputRoot: '',
+  outputDir: '',
+  outputs: [],
+  updated_at: '',
+};
+
+const draftConfirmRequiredFields = [
+  ['softwareName', '软件全称'],
+  ['version', '版本号'],
+  ['developmentCompletedDate', '开发完成日期'],
+  ['copyrightOwner', '著作权人'],
+  ['developmentHardware', '开发硬件环境'],
+  ['runningHardware', '运行硬件环境'],
+  ['developmentOs', '开发操作系统'],
+  ['developmentTools', '开发环境 / 开发工具'],
+  ['runningPlatform', '运行平台 / 操作系统'],
+  ['runtimeSupport', '运行支撑环境 / 支持软件'],
+  ['programmingLanguage', '编程语言'],
+  ['sourceLineCount', '源程序量'],
+  ['developmentPurpose', '开发目的'],
+  ['industry', '面向领域 / 行业'],
+  ['pageCount', '代码材料页数'],
+];
+
+const requiredDraftFiles = [
+  ['business', '业务理解'],
+  ['application', '申请表信息'],
+  ['manual', '操作手册'],
+  ['codeManifest', '代码提取清单'],
+];
+
+function now() {
+  return new Date().toISOString();
+}
+
+function safeJsonParse(value, fallback) {
+  try {
+    return JSON.parse(String(value || ''));
+  } catch {
+    return fallback;
+  }
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function sanitizeFilename(value, fallback = '软著资料') {
+  return String(value || fallback)
+    .replace(/[<>:"/\\|?*\x00-\x1F]/g, '_')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 120) || fallback;
+}
+
+function readText(filePath, limit) {
+  const buffer = fs.readFileSync(filePath);
+  const data = limit ? buffer.subarray(0, limit) : buffer;
+  for (const encoding of ['utf-8', 'utf8', 'gb18030', 'latin1']) {
+    try {
+      return data.toString(encoding);
+    } catch {
+      // Try next encoding.
+    }
+  }
+  return data.toString('utf-8');
+}
+
+function writeJson(filePath, data) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+function readJson(filePath, fallback) {
+  if (!fs.existsSync(filePath)) return fallback;
+  return safeJsonParse(fs.readFileSync(filePath, 'utf-8'), fallback);
+}
+
+function normalizeVersion(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return 'V1.0';
+  return /^v/i.test(raw) ? raw.toUpperCase().replace(/^V/, 'V') : `V${raw}`;
+}
+
+function rel(filePath, root) {
+  return path.relative(root, filePath).split(path.sep).join('/');
+}
+
+function isSkipped(filePath) {
+  const parts = filePath.split(path.sep);
+  if (parts.some((part) => SKIP_DIRS.has(part))) return true;
+  const name = path.basename(filePath);
+  if (SKIP_FILES.has(name)) return true;
+  if (name.endsWith('.map') || name.endsWith('.min.js') || name.endsWith('.min.css')) return true;
+  return false;
+}
+
+function walkFiles(root, results = []) {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const filePath = path.join(root, entry.name);
+    if (isSkipped(filePath)) continue;
+    if (entry.isDirectory()) {
+      walkFiles(filePath, results);
+    } else if (entry.isFile() && CODE_EXTS.has(path.extname(entry.name).toLowerCase())) {
+      const stat = fs.statSync(filePath);
+      if (stat.size > 900_000 || stat.size <= 0) continue;
+      results.push({ filePath, size: stat.size });
+    }
+  }
+  return results;
+}
+
+function classifyFile(relativePath) {
+  const r = relativePath.toLowerCase();
+  const name = path.basename(r);
+  if (['main.ts', 'main.tsx', 'main.js', 'main.jsx', 'app.tsx', 'app.vue', 'index.tsx', 'index.jsx'].includes(name)) return '入口';
+  if (r.includes('/router') || r.includes('/routes') || name.includes('router') || name.includes('route')) return '路由';
+  if (r.includes('/pages/') || r.includes('/views/') || r.includes('/screens/') || r.includes('/app/')) return '页面';
+  if (r.includes('/services/') || r.includes('/api/') || r.includes('/ipc/') || r.includes('/handlers/') || r.includes('/controllers/') || r.includes('/middleware/') || r.includes('/models/') || r.includes('/repositories/')) return '业务服务';
+  if (r.includes('/components/')) return '组件';
+  if (r.includes('/store') || r.includes('/stores') || r.includes('/redux')) return '状态数据';
+  if (r.includes('/utils/') || r.includes('/shared/') || r.includes('/hooks/')) return '通用能力';
+  if (['.css', '.scss', '.less'].includes(path.extname(r))) return '样式';
+  return '源码';
+}
+
+function categoryPriority(category) {
+  const index = ['入口', '路由', '页面', '业务服务', '状态数据', '组件', '通用能力', '源码', '样式'].indexOf(category);
+  return index >= 0 ? index : 99;
+}
+
+function scoreCodeCandidate(item, index = 0) {
+  const normalizedPath = String(item.path || '').toLowerCase();
+  const fileName = path.basename(normalizedPath);
+  let score = CATEGORY_SELECTION_WEIGHT[item.category] || 20;
+  score += SOURCE_EXT_WEIGHT[item.extension] || 0;
+  const lineCount = Math.max(Number(item.line_count) || 0, 0);
+  score += Math.min(lineCount, 280) / 12;
+  score -= index * 0.02;
+  if (lineCount > 900) score -= 28;
+  else if (lineCount > 650) score -= 14;
+
+  if (/(\bsrc\/|\/src\/|^src\/)/u.test(normalizedPath)) score += 18;
+  if (/(feature|features|page|pages|view|views|screen|screens|service|services|api|store|stores|router|route|hook|hooks|component|components)/u.test(normalizedPath)) score += 18;
+  if (/(main|app|index|router|route)\.(ts|tsx|js|jsx|vue)$/u.test(fileName)) score += 18;
+  if (/(service|handler|controller|store|model|schema|api|client|provider|context|hook)\.(ts|tsx|js|jsx|vue|py|java|go|rs|cs)$/u.test(fileName)) score += 12;
+  if (/(test|spec|mock|fixture|demo|example|stories|story|config|setup|vite-env)\./u.test(fileName)) score -= 45;
+  if (/(__tests__|test|tests|spec|mock|mocks|fixture|fixtures|demo|example|examples|storybook|coverage)\//u.test(normalizedPath)) score -= 45;
+  if (/(assets?|public|static|styles?|theme|themes|icons?)\//u.test(normalizedPath)) score -= 24;
+  if (item.category === '样式') score -= 35;
+
+  return score;
+}
+
+function sortCodeCandidates(candidates) {
+  return [...candidates]
+    .map((item, index) => ({ ...item, selection_score: scoreCodeCandidate(item, index) }))
+    .sort((a, b) => b.selection_score - a.selection_score || categoryPriority(a.category) - categoryPriority(b.category) || b.line_count - a.line_count);
+}
+
+function pickRepresentativeCodeFile(items) {
+  if (!items.length) return null;
+  return items.find((item) => item.line_count >= 20 && item.line_count <= 520)
+    || items.find((item) => item.line_count <= 900)
+    || [...items].sort((a, b) => a.line_count - b.line_count || b.selection_score - a.selection_score)[0];
+}
+
+function analyzeProject(projectDir) {
+  const packagePath = ['package.json', 'client/package.json', 'frontend/package.json', 'web/package.json']
+    .map((name) => path.join(projectDir, name))
+    .find((candidate) => fs.existsSync(candidate));
+  const packageJson = packagePath ? readJson(packagePath, {}) : {};
+  const files = walkFiles(projectDir).map((item) => {
+    const relativePath = rel(item.filePath, projectDir);
+    const text = readText(item.filePath, 400_000);
+    const lineCount = text.split(/\r?\n/).length;
+    const category = classifyFile(relativePath);
+    return {
+      path: relativePath,
+      file_path: item.filePath,
+      extension: path.extname(item.filePath).toLowerCase(),
+      size: item.size,
+      line_count: lineCount,
+      category,
+    };
+  });
+
+  files.sort((a, b) => categoryPriority(a.category) - categoryPriority(b.category) || b.line_count - a.line_count);
+  const dependencies = {
+    ...(packageJson.dependencies || {}),
+    ...(packageJson.devDependencies || {}),
+  };
+  const frameworks = Object.keys(dependencies).filter((name) => ['react', 'vue', 'vite', 'electron', 'next', 'typescript'].some((key) => name.toLowerCase().includes(key)));
+  const lineCount = files.reduce((sum, item) => sum + item.line_count, 0);
+  const languages = Array.from(new Set(files.map((item) => item.extension.replace('.', '')).filter(Boolean))).slice(0, 8);
+
+  return {
+    projectRoot: projectDir,
+    projectName: path.basename(projectDir),
+    packageName: packageJson.name || '',
+    packageVersion: packageJson.version || '',
+    scripts: packageJson.scripts || {},
+    frameworks,
+    languages,
+    fileCount: files.length,
+    lineCount,
+    candidates: files.slice(0, 180).map(({ file_path, ...item }) => item),
+    readmeExcerpt: readReadme(projectDir),
+  };
+}
+
+function readReadme(projectDir) {
+  const readme = ['README.md', 'README.zh.md', 'readme.md'].map((name) => path.join(projectDir, name)).find((candidate) => fs.existsSync(candidate));
+  if (!readme) return '';
+  return readText(readme, 5000).split(/\r?\n/).slice(0, 80).join('\n');
+}
+
+function createInitialFieldsFromAnalysis(analysis, currentFields = {}) {
+  const softwareName = currentFields.softwareName || analysis.packageName || analysis.projectName || '';
+  return {
+    ...initialFields,
+    ...currentFields,
+    softwareName,
+    version: currentFields.version || normalizeVersion(analysis.packageVersion || '1.0'),
+    programmingLanguage: currentFields.programmingLanguage || analysis.languages.join('、'),
+    sourceLineCount: currentFields.sourceLineCount || String(analysis.lineCount || ''),
+    developmentPurpose: currentFields.developmentPurpose || '提升软件相关业务处理效率',
+    pageCount: currentFields.pageCount || '',
+  };
+}
+
+function normalizePathList(value) {
+  return Array.from(new Set((Array.isArray(value) ? value : [])
+    .map((item) => String(item || '').trim())
+    .filter(Boolean)));
+}
+
+function selectCodeFiles(analysis, excludedPaths = [], includedPaths = []) {
+  const excluded = new Set(normalizePathList(excludedPaths));
+  const included = normalizePathList(includedPaths).filter((filePath) => !excluded.has(filePath));
+  const candidates = (Array.isArray(analysis.candidates) ? analysis.candidates : [])
+    .filter((item) => !excluded.has(item.path));
+  const selected = [];
+  const selectedPaths = new Set();
+  const targetLines = SPLIT_PAGES * LINES_PER_PAGE;
+  const overflowLimit = Math.round(targetLines * 1.2);
+  const ranked = sortCodeCandidates(candidates);
+  let lines = 0;
+
+  function addItem(item, options = {}) {
+    if (!item || selectedPaths.has(item.path)) return false;
+    const nextLines = lines + item.line_count + 2;
+    if (!options.allowOverflow && selected.length > 0 && nextLines > overflowLimit) return false;
+    selected.push(item);
+    selectedPaths.add(item.path);
+    lines = nextLines;
+    return true;
+  }
+
+  for (const includedPath of included) {
+    addItem(candidates.find((item) => item.path === includedPath), { allowOverflow: true });
+  }
+
+  for (const category of CORE_CODE_CATEGORIES) {
+    const representative = pickRepresentativeCodeFile(ranked.filter((item) => item.category === category));
+    addItem(representative);
+  }
+
+  for (const item of ranked) {
+    if (lines >= targetLines) break;
+    if (item.category === '样式' && lines < targetLines) continue;
+    addItem(item);
+  }
+
+  if (lines < targetLines) {
+    for (const item of ranked) {
+      if (lines >= targetLines) break;
+      addItem(item, { allowOverflow: true });
+    }
+  }
+
+  if (lines < targetLines) {
+    for (const item of candidates) {
+      if (lines >= targetLines) break;
+      addItem(item, { allowOverflow: true });
+    }
+  }
+
+  return selected.length ? selected : candidates.slice(0, 20);
+}
+
+function createCodeMaterial(projectDir, selectedFiles, fields, draftDir) {
+  const allLines = [];
+  const files = [];
+  for (const item of selectedFiles) {
+    const filePath = path.join(projectDir, item.path);
+    if (!fs.existsSync(filePath)) continue;
+    const text = readText(filePath);
+    const sourceLines = text.split(/\r?\n/);
+    const start = allLines.length + 1;
+    allLines.push(`// File: ${item.path}`);
+    allLines.push(...sourceLines);
+    allLines.push('');
+    files.push({
+      path: item.path,
+      category: item.category,
+      selection_score: Number.isFinite(item.selection_score) ? Number(item.selection_score.toFixed(2)) : undefined,
+      source_line_count: sourceLines.length,
+      material_line_start: start,
+      material_line_end: allLines.length,
+    });
+  }
+
+  const pages = [];
+  for (let index = 0; index < allLines.length; index += LINES_PER_PAGE) {
+    pages.push(allLines.slice(index, index + LINES_PER_PAGE));
+  }
+
+  const softwareName = fields.softwareName || '软件';
+  const version = fields.version || 'V1.0';
+  const outputs = [];
+  const writePages = (fileName, title, pageItems) => {
+    const lines = [];
+    for (const [pageNo, pageLines] of pageItems) {
+      lines.push(`## 第 ${pageNo} 页`, '', '```text', ...pageLines, '```', '');
+    }
+    const target = path.join(draftDir, fileName);
+    fs.writeFileSync(target, lines.join('\n'), 'utf-8');
+    outputs.push(target);
+  };
+
+  if (pages.length >= SPLIT_PAGES) {
+    writePages('代码-前30页.md', '代码材料（前30页）', pages.slice(0, 30).map((page, index) => [index + 1, page]));
+    writePages('代码-后30页.md', '代码材料（后30页）', pages.slice(-30).map((page, index) => [pages.length - 29 + index, page]));
+  } else {
+    writePages('代码-全部.md', '代码材料（全部）', pages.map((page, index) => [index + 1, page]));
+  }
+
+  const manifest = {
+    software_name: softwareName,
+    version,
+    project_root: projectDir,
+    lines_per_page: LINES_PER_PAGE,
+    total_pages: pages.length,
+    mode: pages.length >= SPLIT_PAGES ? 'front30_back30' : 'all_under_60_pages',
+    material_line_count: allLines.length,
+    selection_strategy: 'core-category-score-v1',
+    excluded_paths: normalizePathList(fields.codeExcludedPaths),
+    included_paths: normalizePathList(fields.codeIncludedPaths),
+    category_summary: files.reduce((summary, item) => {
+      summary[item.category] = (summary[item.category] || 0) + 1;
+      return summary;
+    }, {}),
+    files,
+  };
+  writeJson(path.join(draftDir, '代码提取清单.json'), manifest);
+  fs.writeFileSync(path.join(draftDir, '代码提取清单.md'), [
+    '# 代码提取清单',
+    '',
+    `- 软件名称：${softwareName}`,
+    `- 版本号：${version}`,
+    `- 总页数：${pages.length}`,
+    `- 材料代码行数：${allLines.length}`,
+    `- 选择策略：核心类别覆盖 + 源码权重排序`,
+    '',
+    '| 文件 | 类型 | 源码行数 | 材料行范围 |',
+    '| --- | --- | ---: | --- |',
+    ...files.map((item) => `| \`${item.path}\` | ${item.category} | ${item.source_line_count} | ${item.material_line_start}-${item.material_line_end} |`),
+    '',
+  ].join('\n'), 'utf-8');
+  return { manifest, outputs };
+}
+
+async function generateBusinessContext(aiService, analysis, fields) {
+  const fallback = {
+    product_positioning: `${fields.softwareName || analysis.projectName}是一套面向实际业务场景的软件系统。`,
+    industry: fields.industry || '通用软件',
+    target_users: ['业务用户', '管理人员'],
+    core_value: '帮助用户完成信息录入、过程处理、结果查看和资料管理等日常工作。',
+    business_features: ['信息管理', '业务处理', '结果查看', '系统设置'],
+    operation_flow: ['进入系统', '填写或导入业务资料', '执行处理任务', '查看并导出结果'],
+    main_functions: fields.mainFunctions || '',
+    technical_characteristics: fields.technicalFeatures || '',
+    manual_modules: [],
+  };
+
+  try {
+    const result = await aiService.requestJson({
+      logTitle: '软著-业务理解',
+      progressLabel: '软著业务理解',
+      temperature: 0.2,
+      timeout_ms: 300000,
+      messages: buildBusinessContextMessages({ analysis, fields }),
+      failureMessage: '软著业务理解 JSON 生成失败',
+    });
+    return { ...fallback, ...result };
+  } catch {
+    return fallback;
+  }
+}
+
+function asArrayText(value, fallback = []) {
+  if (Array.isArray(value)) return value.map((item) => String(item)).filter(Boolean);
+  if (typeof value === 'string' && value.trim()) return value.split(/[；;\n、]+/).map((item) => item.trim()).filter(Boolean);
+  return fallback;
+}
+
+function createApplicationMarkdown(fields, business, manifest) {
+  const mainFunctions = fields.mainFunctions || business.main_functions || `${fields.softwareName}主要提供${asArrayText(business.business_features, ['信息管理', '业务处理']).join('、')}等功能，支持用户完成资料录入、流程处理、结果查看和文档导出等操作。`;
+  const lines = [
+    '# 申请表信息',
+    '',
+    `➤软件全称：${fields.softwareName || '待用户确认'}`,
+    `➤软件简称：${fields.shortName || ''}`,
+    `➤版本号：${fields.version || 'V1.0'}`,
+    `➤软件分类：${fields.category || '应用软件'}`,
+    `➤开发完成日期：${fields.developmentCompletedDate || '待用户确认'}`,
+    `➤开发方式：${fields.developmentMode || '单独开发'}`,
+    `➤软件说明：${fields.softwareDescription || '原创'}`,
+    `➤发表状态：${fields.publishStatus || '未发表'}`,
+    `➤首次发表日期：${fields.firstPublishDate || ''}`,
+    `➤著作权人：${fields.copyrightOwner || '待用户确认'}`,
+    `➤权利范围：${fields.rightsScope || '全部权利'}`,
+    `➤权利取得方式：${fields.rightsAcquisition || '原始取得'}`,
+    `➤开发的硬件环境：${fields.developmentHardware || '待用户确认'}`,
+    `➤运行的硬件环境：${fields.runningHardware || '待用户确认'}`,
+    `➤开发该软件的操作系统：${fields.developmentOs || '待用户确认'}`,
+    `➤软件开发环境 / 开发工具：${fields.developmentTools || '待用户确认'}`,
+    `➤该软件的运行平台 / 操作系统：${fields.runningPlatform || '待用户确认'}`,
+    `➤软件运行支撑环境 / 支持软件：${fields.runtimeSupport || '待用户确认'}`,
+    `➤编程语言：${fields.programmingLanguage || '待用户确认'}`,
+    `➤源程序量：${fields.sourceLineCount || manifest.material_line_count || '待用户确认'}`,
+    `➤开发目的：${fields.developmentPurpose || '提升软件相关业务处理效率'}`,
+    `➤面向领域 / 行业：${fields.industry || business.industry || '待用户确认'}`,
+    `➤软件的主要功能：${mainFunctions}`,
+    `➤软件的技术特点：${fields.technicalFeatures || business.technical_characteristics || '待用户确认'}`,
+    `➤页数：${fields.pageCount || manifest.total_pages}`,
+    '',
+  ];
+  return lines.join('\n');
+}
+
+function syncApplicationCodeStats(markdown, fields, manifest) {
+  const stats = {
+    sourceLineCount: fields.sourceLineCount || manifest.material_line_count || '',
+    pageCount: manifest.total_pages || '',
+  };
+  const lines = String(markdown || '').split(/\r?\n/);
+  let hasSourceLineCount = false;
+  let hasPageCount = false;
+  const nextLines = lines.map((line) => {
+    if (line.startsWith('➤源程序量：')) {
+      hasSourceLineCount = true;
+      return `➤源程序量：${stats.sourceLineCount}`;
+    }
+    if (line.startsWith('➤页数：')) {
+      hasPageCount = true;
+      return `➤页数：${stats.pageCount}`;
+    }
+    return line;
+  });
+  if (!hasSourceLineCount) nextLines.push(`➤源程序量：${stats.sourceLineCount}`);
+  if (!hasPageCount) nextLines.push(`➤页数：${stats.pageCount}`);
+  return nextLines.join('\n');
+}
+
+function createBusinessMarkdown(business) {
+  const businessFeatures = asArrayText(business.business_features)
+    .map((item) => normalizeListItemText(item))
+    .filter(Boolean);
+  const operationFlow = asArrayText(business.operation_flow)
+    .map((item) => normalizeListItemText(item))
+    .filter(Boolean);
+  return [
+    '# 业务理解',
+    '',
+    `## 产品定位`,
+    business.product_positioning || '',
+    '',
+    `## 面向领域 / 行业`,
+    business.industry || '',
+    '',
+    `## 目标用户`,
+    asArrayText(business.target_users).join('、'),
+    '',
+    `## 核心价值`,
+    business.core_value || '',
+    '',
+    `## 主要业务功能`,
+    businessFeatures.map((item) => `- ${item}`).join('\n'),
+    '',
+    `## 典型操作流程`,
+    operationFlow.map((item, index) => `${index + 1}. ${item}`).join('\n'),
+    '',
+  ].join('\n');
+}
+
+function manualModulesFromBusiness(business, analysis) {
+  const modules = Array.isArray(business.manual_modules) ? business.manual_modules : [];
+  if (modules.length) return modules.slice(0, 10);
+  return (analysis.candidates || [])
+    .filter((item) => ['页面', '入口', '路由'].includes(item.category))
+    .slice(0, 8)
+    .map((item) => ({
+      title: item.path.split('/').pop().replace(/\.[^.]+$/, ''),
+      purpose: '用于承载软件中的核心操作页面。',
+      entry: '用户从软件主界面或对应菜单进入。',
+      visible_elements: ['页面标题', '业务内容区', '操作按钮', '结果提示'],
+      operation_steps: ['查看页面信息', '按页面提示填写或选择资料', '提交处理并查看结果'],
+      validation_rules: [],
+      feedback: '处理完成后页面展示结果、状态或提示信息。',
+      screenshot: `请在此处插入 ${item.path} 对应页面截图。`,
+      source_files: [item.path],
+    }));
+}
+
+async function createManualMarkdown(aiService, analysis, fields, business) {
+  const modules = manualModulesFromBusiness(business, analysis);
+  const fallback = buildManualMarkdown(fields, business, modules);
+  try {
+    const text = await aiService.chat({
+      logTitle: '软著-操作手册',
+      temperature: 0.35,
+      timeout_ms: 300000,
+      messages: buildManualMarkdownMessages({ fields, business, modules }),
+    });
+    return text && text.includes('截图预留') ? text : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function buildManualMarkdown(fields, business, modules) {
+  const softwareName = fields.softwareName || '本软件';
+  const moduleSections = modules.map((module, index) => {
+    const title = module.title || `核心功能${index + 1}`;
+    return [
+      `## ${numberCn(index + 5)}、${title}`,
+      '',
+      `${title}主要${module.purpose || '用于完成软件中的相关业务操作'}用户通常从${module.entry || '软件主界面'}进入该页面。页面中可以看到${asArrayText(module.visible_elements, ['业务内容', '操作按钮', '结果区域']).join('、')}等内容。`,
+      '',
+      `使用时，用户可按页面提示${asArrayText(module.operation_steps, ['填写信息', '提交处理', '查看结果']).join('，')}。${asArrayText(module.validation_rules).length ? `页面会校验${asArrayText(module.validation_rules).join('、')}等规则。` : '如信息不完整或处理失败，页面会给出对应提示。'}操作完成后，${module.feedback || '用户可以在页面查看处理结果和状态反馈'}。`,
+      '',
+      `【截图预留：${module.screenshot || `请在此处插入“${title}”页面或操作结果截图。`}】`,
+      '',
+    ].join('\n');
+  }).join('\n');
+
+  return [
+    `# ${softwareName} 操作手册`,
+    '',
+    '## 一、相关文档',
+    '',
+    '| 文档名称 | 说明 |',
+    '| --- | --- |',
+    '| 总体设计说明 | 说明软件目标、用户对象和总体功能组成。 |',
+    '| 详细设计说明 | 说明各功能模块的输入、处理和输出。 |',
+    '| 测试用例 | 记录主要功能的测试过程和结果。 |',
+    '',
+    '## 二、说明',
+    '',
+    `${softwareName}面向${fields.industry || business.industry || '实际业务场景'}，服务于${asArrayText(business.target_users, ['业务用户']).join('、')}。用户可通过软件完成${asArrayText(business.business_features, ['信息管理', '业务处理', '结果查看']).join('、')}等工作。`,
+    '',
+    '## 三、功能特点',
+    '',
+    `${softwareName}围绕真实业务流程组织页面和操作入口，用户可以按照资料准备、内容处理、结果查看和资料导出的顺序完成日常工作。软件在关键步骤提供状态反馈，便于用户确认当前处理进度和结果。`,
+    '',
+    '## 四、系统要求',
+    '',
+    `运行平台为${fields.runningPlatform || '待用户确认'}，运行支撑环境为${fields.runtimeSupport || '待用户确认'}，建议在满足${fields.runningHardware || '常规办公电脑配置'}的设备上使用。`,
+    '',
+    moduleSections,
+    `## ${numberCn(modules.length + 5)}、常见问题解答`,
+    '',
+    '用户在使用过程中如遇到资料无法提交、结果未生成或页面提示异常，应先检查输入内容是否完整，再根据页面提示重新操作。若问题仍然存在，可联系系统维护人员处理。',
+    '',
+    `## ${numberCn(modules.length + 6)}、术语表`,
+    '',
+    '| 术语 | 说明 |',
+    '| --- | --- |',
+    '| 用户 | 使用本软件完成业务处理的人员。 |',
+    '| 结果 | 软件根据用户输入或导入资料处理后形成的页面反馈或导出文件。 |',
+    '',
+  ].join('\n');
+}
+
+function numberCn(value) {
+  const nums = ['零', '一', '二', '三', '四', '五', '六', '七', '八', '九', '十', '十一', '十二', '十三', '十四', '十五'];
+  return nums[value] || String(value);
+}
+
+function paragraph(text, options = {}) {
+  return new Paragraph({
+    text: '',
+    heading: options.heading,
+    alignment: options.alignment,
+    pageBreakBefore: options.pageBreakBefore,
+    spacing: { after: options.after ?? 120, line: options.line ?? 360 },
+    children: options.children || [new TextRun({ text: String(text || ''), font: options.font || '宋体', size: options.size || 24, bold: options.bold, color: options.color || '000000' })],
+  });
+}
+
+function cleanInlineMarkdownText(value) {
+  return String(value || '')
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/\\([\\`*_{}\[\]()#+\-.!|>])/g, '$1');
+}
+
+function inlineMarkdownToRuns(value, options = {}) {
+  const font = options.font || '宋体';
+  const size = options.size || 24;
+  const source = cleanInlineMarkdownText(value);
+  const runs = [];
+  const pattern = /(\*\*([^*]+)\*\*|`([^`]+)`|\*([^*]+)\*)/g;
+  let lastIndex = 0;
+  let match;
+
+  function pushText(text, extra = {}) {
+    if (!text) return;
+    runs.push(new TextRun({
+      text,
+      font: extra.font || font,
+      size,
+      bold: Boolean(extra.bold || options.bold),
+      italics: Boolean(extra.italics),
+      color: extra.color || options.color || '000000',
+    }));
+  }
+
+  while ((match = pattern.exec(source)) !== null) {
+    pushText(source.slice(lastIndex, match.index));
+    if (match[2]) {
+      pushText(match[2], { bold: true });
+    } else if (match[3]) {
+      pushText(match[3], { font: 'Consolas' });
+    } else if (match[4]) {
+      pushText(match[4], { italics: true });
+    }
+    lastIndex = match.index + match[0].length;
+  }
+  pushText(source.slice(lastIndex));
+  return runs.length ? runs : [new TextRun({ text: '', font, size, color: options.color || '000000' })];
+}
+
+function normalizeListItemText(value) {
+  const parts = String(value || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim().replace(/^([-*]\s+|\d+[.、]\s*)+/, '').trim())
+    .filter(Boolean);
+  return parts.join('、').replace(/\s+/g, ' ').trim();
+}
+
+function hasSentenceEnding(value) {
+  return /[。.!！?？；;]$/u.test(String(value || '').trim());
+}
+
+function repairOperationFlowMarkdown(markdown) {
+  const lines = String(markdown || '').split(/\r?\n/);
+  const repaired = [];
+  let inOperationFlow = false;
+  let flowItems = [];
+
+  function flushFlowItems() {
+    if (!flowItems.length) return;
+    repaired.push(...flowItems.map((item, index) => `${index + 1}. ${item}`));
+    flowItems = [];
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    if (/^##\s+典型操作流程\s*$/u.test(line.trim())) {
+      flushFlowItems();
+      inOperationFlow = true;
+      repaired.push(line);
+      continue;
+    }
+    if (inOperationFlow && /^##\s+/u.test(line.trim())) {
+      flushFlowItems();
+      inOperationFlow = false;
+      repaired.push(line);
+      continue;
+    }
+    if (!inOperationFlow) {
+      repaired.push(line);
+      continue;
+    }
+    if (!line.trim()) {
+      flushFlowItems();
+      repaired.push(line);
+      continue;
+    }
+
+    const text = normalizeListItemText(line);
+    if (!text) continue;
+    const previousIndex = flowItems.length - 1;
+    if (previousIndex >= 0 && !hasSentenceEnding(flowItems[previousIndex])) {
+      flowItems[previousIndex] = `${flowItems[previousIndex]}、${text}`;
+    } else {
+      flowItems.push(text);
+    }
+  }
+  flushFlowItems();
+  return repaired.join('\n');
+}
+
+function normalizeDraftContent(draftKey, content) {
+  if (draftKey === 'business') {
+    return repairOperationFlowMarkdown(content);
+  }
+  return String(content || '');
+}
+
+function isMarkdownTableSeparator(line) {
+  return /^\|\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$/u.test(String(line || '').trim());
+}
+
+function parseMarkdownTableRow(line) {
+  return String(line || '')
+    .trim()
+    .replace(/^\|/u, '')
+    .replace(/\|$/u, '')
+    .split('|')
+    .map((cell) => cell.trim());
+}
+
+function markdownTableToDocx(rows, options = {}) {
+  const font = options.bodyFont || '宋体';
+  const size = Math.max(options.bodySize || 21, 21);
+  const border = { style: BorderStyle.SINGLE, size: 4, color: 'BFC7D5' };
+  return new Table({
+    width: { size: 100, type: WidthType.PERCENTAGE },
+    borders: {
+      top: border,
+      right: border,
+      bottom: border,
+      left: border,
+      insideHorizontal: border,
+      insideVertical: border,
+    },
+    rows: rows.map((row, rowIndex) => new TableRow({
+      children: row.map((cell) => new TableCell({
+        width: { size: Math.floor(100 / Math.max(row.length, 1)), type: WidthType.PERCENTAGE },
+        margins: { top: 90, right: 120, bottom: 90, left: 120 },
+        shading: rowIndex === 0 ? { fill: 'F3F6FA' } : undefined,
+        children: [paragraph('', {
+          children: inlineMarkdownToRuns(cell, { font, size, bold: rowIndex === 0 }),
+          line: 300,
+          after: 0,
+        })],
+      })),
+    })),
+  });
+}
+
+function markdownToDocxChildren(markdown, options = {}) {
+  const children = [];
+  const lines = String(markdown || '').split(/\r?\n/);
+  let inCode = false;
+  let codeLines = [];
+  let codeMaterialPageHeadingCount = 0;
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const rawLine = lines[lineIndex];
+    const line = rawLine.trimEnd();
+    if (line.startsWith('```')) {
+      if (inCode) {
+        for (const codeLine of codeLines) {
+          children.push(paragraph(codeLine, {
+            font: options.bodyFont || '宋体',
+            size: Math.max(options.bodySize || 21, 21),
+            line: options.bodyLine || 300,
+            after: options.bodyAfter ?? 0,
+          }));
+        }
+        codeLines = [];
+      }
+      inCode = !inCode;
+      continue;
+    }
+    if (inCode) {
+      codeLines.push(line);
+      continue;
+    }
+    if (!line.trim()) {
+      children.push(new Paragraph({ text: '', spacing: { after: 80 } }));
+      continue;
+    }
+    if (line.startsWith('# ')) {
+      children.push(paragraph(line.slice(2), { heading: HeadingLevel.TITLE, size: 32, bold: true, alignment: AlignmentType.CENTER, after: 220 }));
+    } else if (line.startsWith('## ')) {
+      const isCodeMaterialPageHeading = options.kind === 'code' && /^第\s*\d+\s*页/u.test(line.slice(3).trim());
+      const shouldBreakBeforeCodePage = isCodeMaterialPageHeading && codeMaterialPageHeadingCount > 0;
+      if (isCodeMaterialPageHeading) codeMaterialPageHeadingCount += 1;
+      children.push(paragraph(line.slice(3), {
+        heading: HeadingLevel.HEADING_1,
+        size: 28,
+        bold: true,
+        after: 160,
+        pageBreakBefore: shouldBreakBeforeCodePage,
+      }));
+    } else if (line.startsWith('### ')) {
+      children.push(paragraph(line.slice(4), { heading: HeadingLevel.HEADING_2, size: 25, bold: true, after: 120 }));
+    } else if (isMarkdownTableSeparator(line)) {
+      continue;
+    } else if (line.startsWith('|')) {
+      const tableRows = [];
+      while (lineIndex < lines.length) {
+        const tableLine = lines[lineIndex].trimEnd();
+        if (!tableLine.trim().startsWith('|')) break;
+        if (!isMarkdownTableSeparator(tableLine)) {
+          tableRows.push(parseMarkdownTableRow(tableLine));
+        }
+        lineIndex += 1;
+      }
+      lineIndex -= 1;
+      if (tableRows.length) {
+        children.push(markdownTableToDocx(tableRows, options));
+        children.push(new Paragraph({ text: '', spacing: { after: 80 } }));
+      }
+    } else if (/^[-*]\s+/.test(line)) {
+      const text = normalizeListItemText(line);
+      children.push(paragraph('', {
+        children: [
+          new TextRun({ text: '· ', font: options.bodyFont || '宋体', size: options.bodySize || 24 }),
+          ...inlineMarkdownToRuns(text, { font: options.bodyFont || '宋体', size: options.bodySize || 24 }),
+        ],
+        line: options.bodyLine || 360,
+        after: options.bodyAfter ?? 120,
+      }));
+    } else if (/^\d+\.\s+/.test(line)) {
+      const match = line.match(/^(\d+\.)\s+(.*)$/);
+      const text = normalizeListItemText(match?.[2] || line);
+      children.push(paragraph('', {
+        children: [
+          new TextRun({ text: `${match?.[1] || ''} `, font: options.bodyFont || '宋体', size: options.bodySize || 24 }),
+          ...inlineMarkdownToRuns(text, { font: options.bodyFont || '宋体', size: options.bodySize || 24 }),
+        ],
+        line: options.bodyLine || 360,
+        after: options.bodyAfter ?? 120,
+      }));
+    } else {
+      children.push(paragraph('', {
+        children: inlineMarkdownToRuns(line, { font: options.bodyFont || '宋体', size: options.bodySize || 24 }),
+        font: options.bodyFont || '宋体',
+        size: options.bodySize || 24,
+        line: options.bodyLine || 360,
+        after: options.bodyAfter ?? 120,
+      }));
+    }
+  }
+  return children;
+}
+
+function createManualCoverChildren(fields, softwareName, version) {
+  return [
+    paragraph(`${softwareName} 操作手册`, { size: 38, bold: true, alignment: AlignmentType.CENTER, after: 420 }),
+    paragraph(`版本号：${version}`, { size: 24, alignment: AlignmentType.CENTER, after: 180 }),
+    paragraph(`软件分类：${fields.category || '应用软件'}`, { size: 22, alignment: AlignmentType.CENTER, after: 120 }),
+    paragraph(`著作权人：${fields.copyrightOwner || ''}`, { size: 22, alignment: AlignmentType.CENTER, after: 120 }),
+    paragraph(`开发完成日期：${fields.developmentCompletedDate || ''}`, { size: 22, alignment: AlignmentType.CENTER, after: 600 }),
+    paragraph('本文档用于软件著作权登记材料整理，内容依据软件项目功能和用户操作流程生成。', { size: 21, alignment: AlignmentType.CENTER, line: 320, after: 240 }),
+    paragraph('', { pageBreakBefore: true, after: 0 }),
+  ];
+}
+
+async function writeDocx(markdown, outPath, headerText = '', options = {}) {
+  const coverChildren = options.kind === 'manual'
+    ? createManualCoverChildren(options.fields || {}, options.softwareName || headerText || '软件', options.version || '')
+    : [];
+  const doc = new Document({
+    sections: [{
+      headers: headerText ? { default: new Header({ children: [paragraph(headerText, { size: 21, alignment: AlignmentType.CENTER, after: 80 })] }) } : undefined,
+      footers: {
+        default: new Footer({
+          children: [new Paragraph({ alignment: AlignmentType.CENTER, children: [new TextRun({ children: ['第 ', PageNumber.CURRENT, ' 页'], font: '宋体', size: 21, color: '000000' })] })],
+        }),
+      },
+      properties: {
+        page: {
+          size: A4_PAGE_SIZE,
+          margin: STANDARD_PAGE_MARGIN,
+        },
+      },
+      children: [
+        ...coverChildren,
+        ...markdownToDocxChildren(markdown, options.kind === 'code'
+          ? { kind: 'code', bodyFont: '宋体', bodySize: 21, bodyLine: 240, bodyAfter: 0 }
+          : { kind: options.kind, bodyFont: '宋体', bodySize: 24, bodyLine: 360, bodyAfter: 120 }),
+      ],
+    }],
+  });
+  fs.writeFileSync(outPath, await Packer.toBuffer(doc));
+}
+
+async function maybeGenerateIllustration(aiService, enabled, fields) {
+  if (!enabled) return null;
+  try {
+    const availability = aiService.getImageModelAvailability();
+    if (!availability.available) return null;
+    return await aiService.generateImage({
+      title: '软著操作手册示意图',
+      prompt: buildManualIllustrationPrompt(fields),
+      size: '1024x1024',
+      logTitle: '软著-操作手册示意图',
+    });
+  } catch (error) {
+    return { success: false, message: error.message || '生图失败' };
+  }
+}
+
+function createTask(type) {
+  return {
+    task_id: crypto.randomUUID(),
+    type,
+    status: 'running',
+    progress: 0,
+    logs: [],
+    started_at: now(),
+    updated_at: now(),
+  };
+}
+
+function createRecovery(type, errorMessage) {
+  if (type === 'draft') {
+    return {
+      title: '草稿生成未完成',
+      message: errorMessage || '生成草稿时发生错误，已保留当前项目和申请字段。',
+      actions: ['检查项目目录和模型配置', '确认软件全称、版本号等字段后重新点击“生成草稿”'],
+    };
+  }
+  return {
+    title: '正式资料导出未完成',
+    message: errorMessage || '导出正式资料时发生错误，已保留已确认草稿。',
+    actions: ['检查输出目录权限和草稿完整性', '重新点击“导出正式资料”'],
+  };
+}
+
+function exportItemLabel(key) {
+  const labels = {
+    application: '申请表',
+    manual: '操作手册',
+    code: '代码材料',
+    report: '生成报告',
+  };
+  return labels[key] || key;
+}
+
+function createExportReadmeText({ fields, manifest, state, exportItems, finalOutputs, exportedAt }) {
+  const enabledItems = Object.entries(exportItems)
+    .filter(([, enabled]) => enabled)
+    .map(([key]) => exportItemLabel(key))
+    .join('、') || '未选择';
+  const outputLines = finalOutputs.map((filePath, index) => `${index + 1}. ${path.basename(filePath)}`);
+  const includedLine = Array.isArray(manifest.included_paths) && manifest.included_paths.length
+    ? `手动补充文件：${manifest.included_paths.join('、')}`
+    : '';
+  const excludedLine = Array.isArray(manifest.excluded_paths) && manifest.excluded_paths.length
+    ? `已排除文件：${manifest.excluded_paths.join('、')}`
+    : '';
+  const codeMode = manifest.mode === 'front30_back30'
+    ? '源程序超过 60 页，已按前 30 页和后 30 页导出。'
+    : '源程序未超过 60 页，已按全部代码材料导出。';
+  return [
+    '软著材料导出说明',
+    '',
+    `软件全称：${fields.softwareName || manifest.software_name || ''}`,
+    `版本号：${fields.version || manifest.version || ''}`,
+    `项目目录：${state.project?.path || manifest.project_root || ''}`,
+    `导出时间：${exportedAt}`,
+    `草稿确认时间：${state.draftConfirmedAt || ''}`,
+    `导出项目：${enabledItems}`,
+    '',
+    '代码材料',
+    `代码材料页数：${manifest.total_pages || ''}`,
+    `材料代码行数：${manifest.material_line_count || ''}`,
+    `源码文件数量：${Array.isArray(manifest.files) ? manifest.files.length : ''}`,
+    `导出方式：${codeMode}`,
+    ...(includedLine ? [includedLine] : []),
+    ...(excludedLine ? [excludedLine] : []),
+    '',
+    '输出文件',
+    ...outputLines,
+    '',
+    '重要提醒',
+    '导出材料格式需根据当地受理要求人为微调，请勿直接使用！',
+    '申请表信息、操作手册、代码材料和页眉页脚内容，请在提交前人工复核。',
+    '软件全称、版本号、著作权人、开发完成日期等信息，应与登记申请表保持完全一致。',
+    '',
+  ].join('\n');
+}
+
+function createSoftwareCopyrightService({ app, aiService, configStore, codeGenerationService }) {
+  const rootDir = getSoftwareCopyrightDir(app);
+  const statePath = path.join(rootDir, 'state.json');
+  const subscribers = new Set();
+  let activeTask = null;
+
+  function loadState() {
+    ensureDir(rootDir);
+    const saved = readJson(statePath, null);
+    const availability = aiService.getImageModelAvailability();
+    const codeGenerationMaterials = codeGenerationService?.getConfirmedMaterials?.() || null;
+    return {
+      ...initialState,
+      ...(saved || {}),
+      fields: { ...initialFields, ...(saved?.fields || {}) },
+      options: {
+        ...initialState.options,
+        ...(saved?.options || {}),
+        exportItems: {
+          ...initialState.options.exportItems,
+          ...(saved?.options?.exportItems || {}),
+        },
+      },
+      imageModel: availability,
+      codeGeneration: codeGenerationMaterials
+        ? {
+          available: true,
+          project: codeGenerationMaterials.project,
+          confirmedAt: codeGenerationMaterials.confirmedAt,
+          summary: codeGenerationMaterials.summary,
+        }
+        : {
+          available: false,
+          project: null,
+          confirmedAt: '',
+          summary: null,
+        },
+    };
+  }
+
+  function saveState(partial) {
+    const previous = loadState();
+    const next = {
+      ...previous,
+      ...partial,
+      fields: { ...previous.fields, ...(partial.fields || {}) },
+      options: { ...previous.options, ...(partial.options || {}) },
+      updated_at: now(),
+    };
+    writeJson(statePath, next);
+    return next;
+  }
+
+  function emit(state) {
+    for (const webContents of subscribers) {
+      if (!webContents.isDestroyed()) {
+        webContents.send('software-copyright:event', state);
+      }
+    }
+  }
+
+  function subscribe(webContents) {
+    subscribers.add(webContents);
+    webContents.once('destroyed', () => subscribers.delete(webContents));
+  }
+
+  function updateTask(partial, statePartial = {}) {
+    activeTask = {
+      ...activeTask,
+      ...partial,
+      logs: partial.logs || activeTask.logs,
+      updated_at: now(),
+    };
+    const state = saveState({ ...statePartial, task: activeTask });
+    emit(state);
+    return state;
+  }
+
+  function getDraftPath(state, draftKey) {
+    const filePath = state.drafts?.[draftKey];
+    if (!draftKey || !filePath) {
+      throw new Error('草稿文件不存在');
+    }
+    const normalizedDraftDir = path.resolve(state.draftDir || '');
+    const normalizedFilePath = path.resolve(filePath);
+    if (!normalizedDraftDir || !normalizedFilePath.startsWith(`${normalizedDraftDir}${path.sep}`)) {
+      throw new Error('草稿文件路径无效');
+    }
+    if (!fs.existsSync(normalizedFilePath)) {
+      throw new Error('草稿文件已不存在，请重新生成草稿');
+    }
+    return normalizedFilePath;
+  }
+
+  function validateDraftCompleteness(state = loadState()) {
+    const issues = [];
+    const fields = state.fields || {};
+
+    if (!state.draftDir || !fs.existsSync(state.draftDir)) {
+      issues.push({ type: 'draft', severity: 'error', message: '请先生成草稿。' });
+    }
+
+    for (const [key, label] of draftConfirmRequiredFields) {
+      if (!String(fields[key] || '').trim()) {
+        issues.push({ type: 'field', severity: 'error', key, message: `${label}未填写。` });
+      }
+    }
+
+    if (fields.developmentCompletedDate && !/^\d{4}-\d{2}-\d{2}$/.test(String(fields.developmentCompletedDate))) {
+      issues.push({ type: 'field', severity: 'error', key: 'developmentCompletedDate', message: '开发完成日期格式应为 YYYY-MM-DD。' });
+    }
+
+    for (const [key, label] of [['sourceLineCount', '源程序量'], ['pageCount', '代码材料页数']]) {
+      const value = Number(fields[key]);
+      if (!Number.isFinite(value) || value <= 0) {
+        issues.push({ type: 'field', severity: 'error', key, message: `${label}应为大于 0 的数字。` });
+      }
+    }
+
+    for (const [key, label] of requiredDraftFiles) {
+      const filePath = state.drafts?.[key];
+      if (!filePath) {
+        issues.push({ type: 'draft', severity: 'error', key, message: `缺少${label}草稿。` });
+        continue;
+      }
+      try {
+        const draftPath = getDraftPath(state, key);
+        const content = fs.readFileSync(draftPath, 'utf-8').trim();
+        if (!content) {
+          issues.push({ type: 'draft', severity: 'error', key, message: `${label}草稿内容为空。` });
+        }
+        if (key === 'application' && content.includes('待用户确认')) {
+          issues.push({ type: 'draft', severity: 'error', key, message: '申请表信息仍包含“待用户确认”，请补全后保存。' });
+        }
+      } catch (error) {
+        issues.push({ type: 'draft', severity: 'error', key, message: error.message || `${label}草稿不可读取。` });
+      }
+    }
+
+    const codeDraftKeys = Object.keys(state.drafts || {}).filter((key) => key.startsWith('code'));
+    if (!codeDraftKeys.length) {
+      issues.push({ type: 'code', severity: 'error', message: '缺少代码材料草稿。' });
+    }
+
+    const manifestPath = state.draftMeta?.manifestPath || (state.draftDir ? path.join(state.draftDir, '代码提取清单.json') : '');
+    if (!manifestPath || !fs.existsSync(manifestPath)) {
+      issues.push({ type: 'code', severity: 'error', message: '缺少代码提取清单 JSON，无法核对代码页数。' });
+    } else {
+      const manifest = readJson(manifestPath, {});
+      if (!Number.isFinite(Number(manifest.total_pages)) || Number(manifest.total_pages) <= 0) {
+        issues.push({ type: 'code', severity: 'error', message: '代码提取清单中的总页数无效。' });
+      }
+      if (!Number.isFinite(Number(manifest.material_line_count)) || Number(manifest.material_line_count) <= 0) {
+        issues.push({ type: 'code', severity: 'error', message: '代码提取清单中的材料代码行数无效。' });
+      }
+      if (!Array.isArray(manifest.files) || !manifest.files.length) {
+        issues.push({ type: 'code', severity: 'error', message: '代码提取清单中没有源码文件记录。' });
+      }
+    }
+
+    return {
+      valid: issues.length === 0,
+      issues,
+      checkedAt: now(),
+    };
+  }
+
+  async function runDraftGeneration(payload = {}) {
+    const state = loadState();
+    const sourceMode = payload.sourceMode || state.options.sourceMode || 'project';
+    const codeGenerationMaterials = sourceMode === 'code-generation' ? codeGenerationService?.getConfirmedMaterials?.() : null;
+    const projectDir = codeGenerationMaterials?.project?.path || state.project?.path;
+    if (!projectDir || !fs.existsSync(projectDir)) {
+      throw new Error(sourceMode === 'code-generation' ? '请先在代码生成中确认源码材料' : '请先选择有效的项目目录');
+    }
+    const outRoot = ensureDir(path.join(rootDir, 'outputs', new Date().toISOString().replace(/[:.]/g, '-')));
+    const draftDir = ensureDir(path.join(outRoot, '草稿'));
+    const logs = [];
+    const push = (message, progress, extra = {}) => {
+      logs.push(message);
+      updateTask({ progress, logs: [...logs], ...extra }, extra.state || {});
+    };
+
+    push('正在分析项目源码', 8);
+    const analysis = codeGenerationMaterials?.analysis || analyzeProject(projectDir);
+    const fields = createInitialFieldsFromAnalysis(analysis, { ...state.fields, ...(payload.fields || {}) });
+    saveState({
+      analysis,
+      fields,
+      step: 'generating',
+      drafts: {},
+      draftConfirmed: false,
+      draftConfirmedAt: '',
+      draftDir,
+      outputRoot: outRoot,
+      outputDir: '',
+      outputs: [],
+      draftMeta: null,
+    });
+
+    push('正在生成业务理解', 22);
+    const business = await generateBusinessContext(aiService, analysis, fields);
+    writeJson(path.join(draftDir, '业务理解.json'), business);
+    const businessMarkdown = createBusinessMarkdown(business);
+    fs.writeFileSync(path.join(draftDir, '业务理解.md'), businessMarkdown, 'utf-8');
+
+    push('正在抽取真实源码材料', 40);
+    const codeExcludedPaths = normalizePathList(payload.codeExcludedPaths || state.options.codeExcludedPaths);
+    const codeIncludedPaths = normalizePathList(payload.codeIncludedPaths || state.options.codeIncludedPaths);
+    const selectedFiles = codeGenerationMaterials?.selectedFiles?.length
+      ? codeGenerationMaterials.selectedFiles.filter((item) => !codeExcludedPaths.includes(item.path))
+      : selectCodeFiles(analysis, codeExcludedPaths, codeIncludedPaths);
+    const { manifest, outputs: codeMarkdownFiles } = createCodeMaterial(projectDir, selectedFiles, { ...fields, codeExcludedPaths, codeIncludedPaths }, draftDir);
+    const nextFields = { ...fields, sourceLineCount: fields.sourceLineCount || String(analysis.lineCount), pageCount: String(manifest.total_pages) };
+
+    push('正在整理申请表信息草稿', 55);
+    const applicationMarkdown = createApplicationMarkdown(nextFields, business, manifest);
+    fs.writeFileSync(path.join(draftDir, '申请表信息.md'), applicationMarkdown, 'utf-8');
+
+    push('正在生成操作手册草稿', 70);
+    let manualMarkdown = await createManualMarkdown(aiService, analysis, nextFields, business);
+    const illustration = await maybeGenerateIllustration(aiService, state.options.useAiImages || payload.useAiImages, nextFields);
+    if (illustration?.success && illustration.file_path) {
+      manualMarkdown += `\n\n## 附录、示意图\n\n![软著操作手册示意图](${illustration.file_path})\n`;
+    }
+    fs.writeFileSync(path.join(draftDir, '操作手册.md'), manualMarkdown, 'utf-8');
+    writeJson(path.join(draftDir, '操作手册自检记录.json'), {
+      rounds: [
+        { name: '章节完整性检查', result: '已生成相关文档、说明、功能特点、系统要求、核心功能、常见问题和术语表。' },
+        { name: '真实性检查', result: '核心模块来自项目分析和模型业务理解，代码材料来自真实源码。' },
+        { name: '表达检查', result: '已尽量避免技术实现细节和营销套话。' },
+      ],
+    });
+    fs.writeFileSync(path.join(draftDir, '操作手册自检记录.md'), '# 操作手册自检记录\n\n- 已检查章节完整性。\n- 已检查项目证据和功能表述。\n- 已检查技术化表达和套话。\n', 'utf-8');
+
+    const drafts = {
+      business: path.join(draftDir, '业务理解.md'),
+      application: path.join(draftDir, '申请表信息.md'),
+      manual: path.join(draftDir, '操作手册.md'),
+      codeManifest: path.join(draftDir, '代码提取清单.md'),
+      manualCheck: path.join(draftDir, '操作手册自检记录.md'),
+    };
+    codeMarkdownFiles.forEach((filePath, index) => {
+      drafts[`code${index + 1}`] = filePath;
+    });
+    updateTask({ status: 'success', progress: 100, logs: [...logs, '软著草稿生成完成，请检查确认后导出正式资料'] }, {
+      step: 'draft',
+      analysis,
+      project: codeGenerationMaterials?.project || state.project,
+      fields: nextFields,
+      drafts,
+      draftConfirmed: false,
+      draftDir,
+      outputRoot: outRoot,
+      outputDir: '',
+      outputs: [],
+      draftMeta: {
+        manifestPath: path.join(draftDir, '代码提取清单.json'),
+        codeMarkdownFiles,
+        illustration,
+      },
+    });
+  }
+
+  async function runFinalExport() {
+    const state = loadState();
+    if (!state.draftDir || !fs.existsSync(state.draftDir)) {
+      throw new Error('请先生成草稿');
+    }
+    if (!state.draftConfirmed) {
+      throw new Error('请先确认草稿后再导出正式资料');
+    }
+
+    const finalDir = ensureDir(path.join(state.outputRoot || path.dirname(state.draftDir), '正式资料'));
+    const applicationPath = path.join(state.draftDir, '申请表信息.md');
+    const manualPath = path.join(state.draftDir, '操作手册.md');
+    const manifestPath = state.draftMeta?.manifestPath || path.join(state.draftDir, '代码提取清单.json');
+    if (!fs.existsSync(applicationPath) || !fs.existsSync(manualPath) || !fs.existsSync(manifestPath)) {
+      throw new Error('草稿文件不完整，请重新生成草稿');
+    }
+
+    const fields = state.fields || {};
+    const manifest = readJson(manifestPath, {});
+    const softwareName = sanitizeFilename(fields.softwareName || manifest.software_name || '软件');
+    const version = fields.version || manifest.version || 'V1.0';
+    const exportItems = { ...initialState.options.exportItems, ...(state.options?.exportItems || {}) };
+    if (!Object.values(exportItems).some(Boolean)) {
+      throw new Error('请至少选择一种正式资料导出项');
+    }
+    const finalOutputs = [];
+    if (exportItems.application) {
+      const applicationMarkdown = fs.readFileSync(applicationPath, 'utf-8');
+      const applicationTxtPath = path.join(finalDir, '申请表信息.txt');
+      fs.writeFileSync(applicationTxtPath, applicationMarkdown.split(/\r?\n/).filter((line) => line.startsWith('➤')).join('\n') + '\n', 'utf-8');
+      finalOutputs.push(applicationTxtPath);
+    }
+
+    if (exportItems.manual) {
+      const manualMarkdown = fs.readFileSync(manualPath, 'utf-8');
+      const manualDocxPath = path.join(finalDir, `${softwareName}_操作手册.docx`);
+      await writeDocx(manualMarkdown, manualDocxPath, `${softwareName} ${version}`, {
+        kind: 'manual',
+        fields,
+        softwareName,
+        version,
+      });
+      finalOutputs.push(manualDocxPath);
+    }
+
+    if (exportItems.code) {
+      const codeMarkdownFiles = Array.isArray(state.draftMeta?.codeMarkdownFiles) && state.draftMeta.codeMarkdownFiles.length
+        ? state.draftMeta.codeMarkdownFiles
+        : Object.values(state.drafts || {}).filter((filePath) => /^代码-.*\.md$/u.test(path.basename(String(filePath || ''))));
+      for (const mdPath of codeMarkdownFiles) {
+        if (!fs.existsSync(mdPath)) continue;
+        const md = fs.readFileSync(mdPath, 'utf-8');
+        const suffix = path.basename(mdPath).replace(/^代码-/, '').replace(/\.md$/, '');
+        const docxPath = path.join(finalDir, `${softwareName}-代码(${suffix}).docx`);
+        await writeDocx(md, docxPath, `${softwareName} ${version} 源程序`, { kind: 'code' });
+        finalOutputs.push(docxPath);
+      }
+    }
+
+    const exportedAt = now();
+
+    if (exportItems.report) {
+      const reportPath = path.join(finalDir, '生成报告.md');
+      const reportOutputs = [...finalOutputs, reportPath];
+      fs.writeFileSync(reportPath, [
+        '# 生成报告',
+        '',
+        `- 软件名称：${softwareName}`,
+        `- 版本号：${version}`,
+        `- 项目目录：${state.project?.path || manifest.project_root || ''}`,
+        `- 代码材料页数：${manifest.total_pages || ''}`,
+        `- 草稿确认时间：${state.draftConfirmedAt || ''}`,
+        `- 导出时间：${exportedAt}`,
+        `- 导出选项：${Object.entries(exportItems).filter(([, enabled]) => enabled).map(([key]) => exportItemLabel(key)).join('、')}`,
+        state.draftMeta?.illustration?.success ? `- 生图结果：${state.draftMeta.illustration.file_path}` : '- 生图结果：未使用或未生成',
+        '',
+        '## 输出文件',
+        '',
+        ...reportOutputs.map((filePath) => `- ${path.basename(filePath)}`),
+        '',
+        '## 格式说明',
+        '',
+        exportItems.manual ? '- 操作手册 DOCX 包含封面、页眉和页码。' : '',
+        exportItems.code ? '- 代码材料 DOCX 使用等宽字体和紧凑行距，便于核对源程序内容。' : '',
+        '',
+      ].filter((line) => line !== '').join('\n'), 'utf-8');
+      finalOutputs.push(reportPath);
+    }
+
+    const readmePath = path.join(finalDir, '导出说明.txt');
+    fs.writeFileSync(readmePath, createExportReadmeText({
+      fields,
+      manifest,
+      state,
+      exportItems,
+      finalOutputs,
+      exportedAt,
+    }), 'utf-8');
+    finalOutputs.push(readmePath);
+
+    updateTask({ status: 'success', progress: 100, logs: ['正式资料导出完成'] }, {
+      step: 'result',
+      outputs: finalOutputs.map((filePath) => ({ name: path.basename(filePath), path: filePath })),
+      outputDir: finalDir,
+    });
+  }
+
+  return {
+    subscribe,
+    loadState,
+    async selectProject() {
+      const result = await dialog.showOpenDialog({ properties: ['openDirectory'], title: '选择需要生成软著资料的项目目录' });
+      if (result.canceled || !result.filePaths?.[0]) {
+        return { success: false, message: '已取消选择', state: loadState() };
+      }
+      const projectDir = result.filePaths[0];
+      const analysis = analyzeProject(projectDir);
+      const state = saveState({
+        step: 'setup',
+        project: { path: projectDir, name: path.basename(projectDir) },
+        analysis,
+        fields: createInitialFieldsFromAnalysis(analysis, loadState().fields),
+        task: undefined,
+        drafts: {},
+        draftConfirmed: false,
+        draftConfirmedAt: '',
+        draftDir: '',
+        outputRoot: '',
+        outputDir: '',
+        outputs: [],
+        draftMeta: null,
+      });
+      return { success: true, state };
+    },
+    saveFields(fields) {
+      return saveState({ fields: { ...(fields || {}) } });
+    },
+    saveOptions(options) {
+      return saveState({ options: { ...(options || {}) } });
+    },
+    readDraft(draftKey) {
+      const state = loadState();
+      const filePath = getDraftPath(state, draftKey);
+      const originalContent = fs.readFileSync(filePath, 'utf-8');
+      const content = normalizeDraftContent(draftKey, originalContent);
+      if (content !== originalContent) {
+        fs.writeFileSync(filePath, content, 'utf-8');
+      }
+      return {
+        key: draftKey,
+        name: path.basename(filePath),
+        path: filePath,
+        content,
+        updatedAt: fs.statSync(filePath).mtime.toISOString(),
+      };
+    },
+    readCodeManifest() {
+      const state = loadState();
+      const manifestPath = state.draftMeta?.manifestPath || (state.draftDir ? path.join(state.draftDir, '代码提取清单.json') : '');
+      if (!manifestPath || !fs.existsSync(manifestPath)) {
+        return null;
+      }
+      const normalizedDraftDir = path.resolve(state.draftDir || '');
+      const normalizedManifestPath = path.resolve(manifestPath);
+      if (!normalizedDraftDir || !normalizedManifestPath.startsWith(`${normalizedDraftDir}${path.sep}`)) {
+        throw new Error('代码提取清单路径无效');
+      }
+      return readJson(normalizedManifestPath, null);
+    },
+    regenerateCodeMaterial(payload = {}) {
+      const state = loadState();
+      if (activeTask?.status === 'running' || state.task?.status === 'running') {
+        throw new Error('当前有软著任务正在运行，请稍后再重新抽取代码材料');
+      }
+      if (!state.draftDir || !fs.existsSync(state.draftDir)) {
+        throw new Error('请先生成草稿后再重新抽取代码材料');
+      }
+
+      const sourceMode = payload.sourceMode || state.options.sourceMode || 'project';
+      const codeGenerationMaterials = sourceMode === 'code-generation' ? codeGenerationService?.getConfirmedMaterials?.() : null;
+      const projectDir = codeGenerationMaterials?.project?.path || state.project?.path;
+      if (!projectDir || !fs.existsSync(projectDir)) {
+        throw new Error(sourceMode === 'code-generation' ? '请先在代码生成中确认源码材料' : '请先选择有效的项目目录');
+      }
+
+      const analysis = codeGenerationMaterials?.analysis || analyzeProject(projectDir);
+      const fields = createInitialFieldsFromAnalysis(analysis, { ...state.fields, ...(payload.fields || {}) });
+      const codeExcludedPaths = normalizePathList(payload.codeExcludedPaths || state.options.codeExcludedPaths);
+      const codeIncludedPaths = normalizePathList(payload.codeIncludedPaths || state.options.codeIncludedPaths);
+      const selectedFiles = codeGenerationMaterials?.selectedFiles?.length
+        ? codeGenerationMaterials.selectedFiles.filter((item) => !codeExcludedPaths.includes(item.path))
+        : selectCodeFiles(analysis, codeExcludedPaths, codeIncludedPaths);
+      const { manifest, outputs: codeMarkdownFiles } = createCodeMaterial(projectDir, selectedFiles, { ...fields, codeExcludedPaths, codeIncludedPaths }, state.draftDir);
+      const nextFields = {
+        ...fields,
+        sourceLineCount: fields.sourceLineCount || String(analysis.lineCount || manifest.material_line_count || ''),
+        pageCount: String(manifest.total_pages),
+      };
+
+      const applicationPath = state.drafts?.application || path.join(state.draftDir, '申请表信息.md');
+      if (fs.existsSync(applicationPath)) {
+        const applicationMarkdown = fs.readFileSync(applicationPath, 'utf-8');
+        fs.writeFileSync(applicationPath, syncApplicationCodeStats(applicationMarkdown, nextFields, manifest), 'utf-8');
+      }
+
+      const nextDrafts = Object.fromEntries(
+        Object.entries(state.drafts || {}).filter(([key]) => !key.startsWith('code')),
+      );
+      nextDrafts.codeManifest = path.join(state.draftDir, '代码提取清单.md');
+      codeMarkdownFiles.forEach((filePath, index) => {
+        nextDrafts[`code${index + 1}`] = filePath;
+      });
+
+      const nextState = saveState({
+        step: 'draft',
+        analysis,
+        project: codeGenerationMaterials?.project || state.project,
+        fields: nextFields,
+        drafts: nextDrafts,
+        draftConfirmed: false,
+        draftConfirmedAt: '',
+        outputDir: '',
+        outputs: [],
+        draftMeta: {
+          ...(state.draftMeta || {}),
+          manifestPath: path.join(state.draftDir, '代码提取清单.json'),
+          codeMarkdownFiles,
+        },
+        task: undefined,
+      });
+      emit(nextState);
+      return { state: nextState, manifest };
+    },
+    saveDraft({ key, content }) {
+      const state = loadState();
+      const filePath = getDraftPath(state, key);
+      fs.writeFileSync(filePath, normalizeDraftContent(key, content), 'utf-8');
+      const next = saveState({
+        draftConfirmed: false,
+        draftConfirmedAt: '',
+        step: 'draft',
+      });
+      emit(next);
+      return {
+        key,
+        name: path.basename(filePath),
+        path: filePath,
+        content: fs.readFileSync(filePath, 'utf-8'),
+        updatedAt: fs.statSync(filePath).mtime.toISOString(),
+        state: next,
+      };
+    },
+    validateDraft() {
+      return validateDraftCompleteness();
+    },
+    startGeneration(payload) {
+      if (activeTask?.status === 'running') {
+        return activeTask;
+      }
+      activeTask = createTask('software-copyright-draft-generation');
+      const state = saveState({ task: activeTask, step: 'generating' });
+      emit(state);
+      runDraftGeneration(payload).catch((error) => {
+        const message = error.message || '软著草稿生成失败';
+        updateTask({
+          status: 'error',
+          progress: 100,
+          error: message,
+          recovery: createRecovery('draft', message),
+          logs: [...(activeTask.logs || []), message],
+        }, { step: loadState().draftDir ? 'draft' : 'setup' });
+      }).finally(() => {
+        activeTask = null;
+      });
+      return activeTask;
+    },
+    confirmDraft() {
+      const state = loadState();
+      if (!state.draftDir || !fs.existsSync(state.draftDir)) {
+        throw new Error('请先生成草稿');
+      }
+      const validation = validateDraftCompleteness(state);
+      if (!validation.valid) {
+        throw new Error(`草稿检查未通过：${validation.issues.slice(0, 3).map((issue) => issue.message).join('；')}`);
+      }
+      const next = saveState({ draftConfirmed: true, draftConfirmedAt: now(), step: 'draft' });
+      emit(next);
+      return next;
+    },
+    exportFinal(payload = {}) {
+      if (activeTask?.status === 'running') {
+        return activeTask;
+      }
+      activeTask = createTask('software-copyright-final-export');
+      const state = saveState({
+        task: activeTask,
+        step: 'exporting',
+        options: payload.exportItems ? { exportItems: payload.exportItems } : {},
+      });
+      emit(state);
+      runFinalExport().catch((error) => {
+        const message = error.message || '正式资料导出失败';
+        updateTask({
+          status: 'error',
+          progress: 100,
+          error: message,
+          recovery: createRecovery('export', message),
+          logs: [...(activeTask.logs || []), message],
+        }, { step: 'draft' });
+      }).finally(() => {
+        activeTask = null;
+      });
+      return activeTask;
+    },
+    clear() {
+      const next = { ...initialState, updated_at: now(), imageModel: aiService.getImageModelAvailability() };
+      writeJson(statePath, next);
+      const state = loadState();
+      emit(state);
+      return { success: true, state };
+    },
+    async openOutputDir() {
+      const state = loadState();
+      const target = state.outputDir || state.draftDir || rootDir;
+      ensureDir(target);
+      await shell.openPath(target);
+      return { success: true, path: target };
+    },
+  };
+}
+
+module.exports = {
+  createSoftwareCopyrightService,
+};

--- a/client/electron/utils/paths.cjs
+++ b/client/electron/utils/paths.cjs
@@ -53,6 +53,14 @@ function getKnowledgeBaseDir(app) {
   return path.join(getWorkspaceDir(app), 'knowledge-base');
 }
 
+function getSoftwareCopyrightDir(app) {
+  return path.join(getWorkspaceDir(app), 'software-copyright');
+}
+
+function getCodeGenerationDir(app) {
+  return path.join(getWorkspaceDir(app), 'code-generation');
+}
+
 function getAiLogsDir(app) {
   return path.join(getUserDataPath(app), 'logs', 'ai');
 }
@@ -65,6 +73,8 @@ module.exports = {
   getGeneratedImagesDir,
   getImportedImagesDir,
   getKnowledgeBaseDir,
+  getCodeGenerationDir,
+  getSoftwareCopyrightDir,
   getRejectionCheckDir,
   getRejectionCheckDocumentMarkdownPath,
   getTechnicalPlanDir,

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "postinstall": "electron-builder install-app-deps",
     "preview": "vite preview --host 127.0.0.1 --port 4173",
     "smoke:electron-native": "electron scripts/electron-native-smoke.cjs",
+    "verify:software-copyright": "node scripts/verify-software-copyright.cjs",
     "start": "electron ."
   },
   "build": {

--- a/client/scripts/verify-software-copyright.cjs
+++ b/client/scripts/verify-software-copyright.cjs
@@ -1,0 +1,292 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { createSoftwareCopyrightService } = require('../electron/services/softwareCopyrightService.cjs');
+const { getSoftwareCopyrightDir } = require('../electron/utils/paths.cjs');
+
+const DEFAULT_TIMEOUT_MS = 90_000;
+
+function createTempApp() {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'yibiao-sc-verify-'));
+  return {
+    userData,
+    app: {
+      getPath(name) {
+        if (name !== 'userData') {
+          throw new Error(`Unsupported app path requested: ${name}`);
+        }
+        return userData;
+      },
+    },
+  };
+}
+
+function createMockAiService(fields) {
+  return {
+    getImageModelAvailability() {
+      return { available: false, status: 'verify-disabled', message: '软著验证脚本未启用生图模型' };
+    },
+    async requestJson() {
+      return {
+        product_positioning: `${fields.softwareName}是一套面向招投标资料编制与审查场景的桌面应用。`,
+        industry: fields.industry,
+        target_users: ['投标专员', '项目经理', '企业管理人员'],
+        core_value: '帮助用户整理招投标资料、生成文档内容并检查响应完整性。',
+        business_features: ['技术方案生成', '商务标资料管理', '知识库检索', '标书查重', '废标项检查', '软著资料生成'],
+        operation_flow: ['进入系统', '选择业务功能', '导入或填写资料', '启动生成或检查任务', '查看结果并导出资料'],
+        main_functions: fields.mainFunctions,
+        technical_characteristics: fields.technicalFeatures,
+        manual_modules: [
+          {
+            title: '技术方案',
+            purpose: '用于生成和编辑投标技术方案正文。',
+            entry: '左侧导航栏的技术方案菜单',
+            visible_elements: ['步骤区域', '正文编辑区', '导出按钮'],
+            operation_steps: ['导入招标文件', '生成目录', '生成正文', '检查并导出文档'],
+            validation_rules: ['招标文件不能为空', '目录节点需有效'],
+            feedback: '页面展示生成进度、正文内容和导出结果。',
+            screenshot: '技术方案页面截图预留位',
+          },
+          {
+            title: '软著生成',
+            purpose: '用于生成软件著作权申请表、操作手册和代码材料。',
+            entry: '左侧导航栏的软件著作/软著生成菜单',
+            visible_elements: ['项目来源', '申请字段', '任务进度', '草稿资料', '正式资料'],
+            operation_steps: ['选择项目', '补全字段', '生成草稿', '检查并确认草稿', '导出正式资料'],
+            validation_rules: ['软件名称不能为空', '草稿需完整'],
+            feedback: '页面展示草稿检查结果和正式资料路径。',
+            screenshot: '软著生成页面截图预留位',
+          },
+        ],
+      };
+    },
+    async chat() {
+      return [
+        `# ${fields.softwareName} 操作手册`,
+        '',
+        '## 一、相关文档',
+        '',
+        '| 文档名称 | 说明 |',
+        '| --- | --- |',
+        '| 总体设计说明 | 说明软件目标、用户对象和总体功能组成。 |',
+        '| 详细设计说明 | 说明各功能模块的输入、处理和输出。 |',
+        '| 测试用例 | 记录主要功能的测试过程和结果。 |',
+        '',
+        '## 二、说明',
+        '',
+        `${fields.softwareName}面向${fields.industry}场景，用户可通过软件完成资料导入、内容生成、材料检查和结果导出等工作。`,
+        '',
+        '## 三、功能特点',
+        '',
+        '软件围绕招投标资料处理流程组织功能入口，并在关键步骤展示任务进度和处理结果。',
+        '',
+        '## 四、系统要求',
+        '',
+        `运行平台为${fields.runningPlatform}，运行支撑环境为${fields.runtimeSupport}。`,
+        '',
+        '## 五、技术方案',
+        '',
+        '用户从左侧导航栏进入技术方案页面，导入招标文件后可生成目录和正文内容。',
+        '',
+        '【截图预留：技术方案页面截图预留位】',
+        '',
+        '## 六、软著生成',
+        '',
+        '用户从软件著作菜单进入软著生成页面，选择项目并补全字段后生成草稿，检查通过后导出正式资料。',
+        '',
+        '【截图预留：软著生成页面截图预留位】',
+        '',
+        '## 七、常见问题解答',
+        '',
+        '如生成结果不完整，用户应检查输入字段和项目源码后重新生成。',
+        '',
+        '## 八、术语表',
+        '',
+        '| 术语 | 说明 |',
+        '| --- | --- |',
+        '| 草稿 | 正式导出前可编辑确认的软著材料。 |',
+        '| 正式资料 | 确认草稿后导出的申请表、手册和代码材料。 |',
+        '',
+      ].join('\n');
+    },
+  };
+}
+
+function createVerifyFields() {
+  return {
+    softwareName: '禹都AI投标助手软件',
+    shortName: '禹都AI投标助手',
+    version: 'V1.0',
+    category: '应用软件',
+    developmentCompletedDate: '2026-06-08',
+    developmentMode: '单独开发',
+    softwareDescription: '原创',
+    publishStatus: '未发表',
+    firstPublishDate: '',
+    copyrightOwner: '中国/河南省/企业/禹都科技有限公司/统一社会信用代码待补充',
+    rightsScope: '全部权利',
+    rightsAcquisition: '原始取得',
+    developmentHardware: 'Apple Silicon/16GB/512GB',
+    runningHardware: '常规办公电脑/8GB内存及以上',
+    developmentOs: 'macOS 15',
+    developmentTools: 'VS Code、Vite、Electron',
+    runningPlatform: 'Windows 10 及以上、macOS 13 及以上',
+    runtimeSupport: 'Electron、Chromium、Node.js',
+    programmingLanguage: 'TypeScript、JavaScript、CSS',
+    sourceLineCount: '',
+    developmentPurpose: '提升招投标资料编制效率',
+    industry: '招投标与企业办公软件',
+    mainFunctions: '招标文件解析、技术方案生成、商务标资料管理、知识库检索、标书查重、废标项检查、软著材料生成。',
+    technicalFeatures: '桌面端 Electron 应用，支持 Markdown 编辑、AI 文档生成、Word 导出和本地工作区存储。',
+    pageCount: '',
+  };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForTask(service, type, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const state = service.loadState();
+    if (state.task?.type === type && state.task.status !== 'running') {
+      return state;
+    }
+    await sleep(200);
+  }
+  throw new Error(`等待任务超时：${type}`);
+}
+
+function writeInitialState(app, projectDir, fields) {
+  const rootDir = getSoftwareCopyrightDir(app);
+  fs.mkdirSync(rootDir, { recursive: true });
+  fs.writeFileSync(path.join(rootDir, 'state.json'), JSON.stringify({
+    step: 'setup',
+    project: { path: projectDir, name: path.basename(projectDir) },
+    fields,
+    options: {
+      sourceMode: 'project',
+      screenshotMode: 'skip',
+      useAiImages: false,
+      exportItems: {
+        application: true,
+        manual: true,
+        code: true,
+        report: true,
+      },
+      codeExcludedPaths: [],
+      codeIncludedPaths: [],
+    },
+    drafts: {},
+    draftConfirmed: false,
+    outputDir: '',
+    outputs: [],
+  }, null, 2), 'utf-8');
+}
+
+function assertOutputFiles(outputs) {
+  if (!Array.isArray(outputs) || outputs.length < 4) {
+    throw new Error(`正式资料数量异常：${outputs?.length || 0}`);
+  }
+  for (const output of outputs) {
+    const stat = fs.statSync(output.path);
+    if (!stat.isFile() || stat.size <= 0) {
+      throw new Error(`正式资料为空或不可读：${output.path}`);
+    }
+  }
+}
+
+function inspectOutputs(state) {
+  const manifestPath = path.join(state.draftDir, '代码提取清单.json');
+  const applicationPath = path.join(state.outputDir, '申请表信息.txt');
+  const reportPath = path.join(state.outputDir, '生成报告.md');
+  const readmePath = path.join(state.outputDir, '导出说明.txt');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  const application = fs.readFileSync(applicationPath, 'utf-8');
+  const report = fs.readFileSync(reportPath, 'utf-8');
+  const readme = fs.readFileSync(readmePath, 'utf-8');
+  if (application.includes('待用户确认')) {
+    throw new Error('申请表信息仍包含“待用户确认”。');
+  }
+  if (!readme.includes('导出材料格式需根据当地受理要求人为微调，请勿直接使用')) {
+    throw new Error('导出说明缺少人工微调提醒。');
+  }
+  return {
+    draftCount: Object.keys(state.drafts || {}).length,
+    outputCount: state.outputs.length,
+    totalPages: manifest.total_pages,
+    materialLineCount: manifest.material_line_count,
+    manifestFileCount: Array.isArray(manifest.files) ? manifest.files.length : 0,
+    reportExcerpt: report.split(/\r?\n/).slice(0, 8),
+    readmeExcerpt: readme.split(/\r?\n/).slice(0, 8),
+  };
+}
+
+async function run() {
+  const projectDir = path.resolve(process.env.SOFTWARE_COPYRIGHT_VERIFY_PROJECT || path.join(process.cwd(), 'src'));
+  if (!fs.existsSync(projectDir)) {
+    throw new Error(`验证项目不存在：${projectDir}`);
+  }
+
+  const { app, userData } = createTempApp();
+  const fields = createVerifyFields();
+  writeInitialState(app, projectDir, fields);
+
+  const service = createSoftwareCopyrightService({
+    app,
+    aiService: createMockAiService(fields),
+    configStore: {},
+    codeGenerationService: null,
+  });
+
+  console.log(`[software-copyright-verify] project=${projectDir}`);
+  console.log(`[software-copyright-verify] userData=${userData}`);
+
+  service.startGeneration({ fields, sourceMode: 'project', useAiImages: false });
+  const draftState = await waitForTask(service, 'software-copyright-draft-generation');
+  if (draftState.task.status !== 'success') {
+    throw new Error(draftState.task.error || '草稿生成失败');
+  }
+
+  const applicationDraft = service.readDraft('application');
+  service.saveDraft({ key: 'application', content: `${applicationDraft.content}\n<!-- verify draft save -->\n` });
+
+  const validation = service.validateDraft();
+  if (!validation.valid) {
+    throw new Error(`草稿检查未通过：${validation.issues.map((issue) => issue.message).join('；')}`);
+  }
+
+  const confirmedState = service.confirmDraft();
+  if (!confirmedState.draftConfirmed) {
+    throw new Error('草稿确认状态未写入。');
+  }
+
+  service.exportFinal();
+  const finalState = await waitForTask(service, 'software-copyright-final-export');
+  if (finalState.task.status !== 'success') {
+    throw new Error(finalState.task.error || '正式资料导出失败');
+  }
+
+  assertOutputFiles(finalState.outputs);
+  const inspected = inspectOutputs(finalState);
+
+  console.log('[software-copyright-verify] passed');
+  console.log(JSON.stringify({
+    draftDir: finalState.draftDir,
+    outputDir: finalState.outputDir,
+    validationIssueCount: validation.issues.length,
+    outputs: finalState.outputs.map((output) => ({
+      name: output.name,
+      path: output.path,
+      size: fs.statSync(output.path).size,
+    })),
+    inspected,
+  }, null, 2));
+}
+
+run().catch((error) => {
+  console.error('[software-copyright-verify] failed');
+  console.error(error?.stack || error?.message || String(error));
+  process.exit(1);
+});

--- a/client/src/app/AppRouter.tsx
+++ b/client/src/app/AppRouter.tsx
@@ -1,11 +1,13 @@
 import type { SectionId } from '../shared/types/navigation';
 import BidOpportunityPage from '../features/bid-opportunity/pages/BidOpportunityPage';
 import BusinessBidPage from '../features/business-bid/pages/BusinessBidPage';
+import CodeGenerationPage from '../features/code-generation/pages/CodeGenerationPage';
 import DeveloperTestPage from '../features/developer/pages/DeveloperTestPage';
 import DuplicateCheckPage from '../features/duplicate-check/pages/DuplicateCheckPage';
 import KnowledgeBasePage from '../features/knowledge-base/pages/KnowledgeBasePage';
 import RejectionCheckPage from '../features/rejection-check/pages/RejectionCheckPage';
 import SettingsPage from '../features/settings/pages/SettingsPage';
+import SoftwareCopyrightPage from '../features/software-copyright/pages/SoftwareCopyrightPage';
 import TechnicalPlanHome from '../features/technical-plan/pages/TechnicalPlanHome';
 
 interface AppRouterProps {
@@ -19,6 +21,10 @@ function AppRouter({ activeSection, onDeveloperModeChange }: AppRouterProps) {
       return <TechnicalPlanHome />;
     case 'business-bid':
       return <BusinessBidPage />;
+    case 'code-generation':
+      return <CodeGenerationPage />;
+    case 'software-copyright':
+      return <SoftwareCopyrightPage />;
     case 'knowledge-base':
       return <KnowledgeBasePage />;
     case 'duplicate-check':

--- a/client/src/app/menuConfig.ts
+++ b/client/src/app/menuConfig.ts
@@ -1,4 +1,4 @@
-import type { AppMenuItem, SectionId } from '../shared/types/navigation';
+import type { AppMenuGroup, AppMenuItem, SectionId } from '../shared/types/navigation';
 
 export const appMenuItems: AppMenuItem[] = [
   {
@@ -33,6 +33,19 @@ export const appMenuItems: AppMenuItem[] = [
   },
 ];
 
+const softwareCopyrightMenuItems: AppMenuItem[] = [
+  {
+    id: 'code-generation',
+    label: '代码生成',
+    description: '软著源码材料准备',
+  },
+  {
+    id: 'software-copyright',
+    label: '软著生成',
+    description: '申请表、手册与代码材料',
+  },
+];
+
 const developerMenuItems: AppMenuItem[] = [
   {
     id: 'developer-test',
@@ -41,8 +54,36 @@ const developerMenuItems: AppMenuItem[] = [
   },
 ];
 
+export function getAppMenuGroups(developerMode: boolean): AppMenuGroup[] {
+  const groups: AppMenuGroup[] = [
+    {
+      id: 'bid',
+      label: '招投标',
+      items: appMenuItems,
+    },
+    {
+      id: 'copyright',
+      label: '软件著作',
+      items: softwareCopyrightMenuItems,
+    },
+  ];
+
+  if (!developerMode) {
+    return groups;
+  }
+
+  return [
+    ...groups,
+    {
+      id: 'developer',
+      label: '开发调试',
+      items: developerMenuItems,
+    },
+  ];
+}
+
 export function getAppMenuItems(developerMode: boolean): AppMenuItem[] {
-  return developerMode ? [...appMenuItems, ...developerMenuItems] : appMenuItems;
+  return getAppMenuGroups(developerMode).flatMap((group) => group.items);
 }
 
 export function getSectionOrder(developerMode: boolean): SectionId[] {

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { useEffect, useState, type ComponentType, type ReactElement, type SVGProps } from 'react';
-import { getAppMenuItems } from '../app/menuConfig';
+import { getAppMenuGroups } from '../app/menuConfig';
 import type { SectionId } from '../shared/types/navigation';
 import logoUrl from '../../assets/icon_256.png';
 
@@ -13,6 +13,8 @@ interface SidebarProps {
 const navigationIcons: Record<SectionId, ComponentType<SVGProps<SVGSVGElement>>> = {
   'technical-plan': DocumentIcon,
   'business-bid': BriefcaseIcon,
+  'code-generation': CodeIcon,
+  'software-copyright': CertificateIcon,
   'knowledge-base': ArchiveIcon,
   'duplicate-check': CompareIcon,
   'rejection-check': ShieldIcon,
@@ -22,19 +24,38 @@ const navigationIcons: Record<SectionId, ComponentType<SVGProps<SVGSVGElement>>>
 };
 
 const SIDEBAR_COLLAPSED_KEY = 'yudubid-sidebar-collapsed';
+const SIDEBAR_GROUPS_COLLAPSED_KEY = 'yudubid-sidebar-groups-collapsed';
 
 function loadInitialCollapsed() {
   if (typeof window === 'undefined') return false;
   return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true';
 }
 
+function loadInitialCollapsedGroups() {
+  if (typeof window === 'undefined') return {};
+  try {
+    return JSON.parse(window.localStorage.getItem(SIDEBAR_GROUPS_COLLAPSED_KEY) || '{}') as Record<string, boolean>;
+  } catch {
+    return {};
+  }
+}
+
 function Sidebar({ activeSection, developerMode, onSectionChange }: SidebarProps) {
   const [collapsed, setCollapsed] = useState(loadInitialCollapsed);
-  const menuItems = getAppMenuItems(developerMode);
+  const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>(loadInitialCollapsedGroups);
+  const menuGroups = getAppMenuGroups(developerMode);
 
   useEffect(() => {
     window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(collapsed));
   }, [collapsed]);
+
+  useEffect(() => {
+    window.localStorage.setItem(SIDEBAR_GROUPS_COLLAPSED_KEY, JSON.stringify(collapsedGroups));
+  }, [collapsedGroups]);
+
+  function toggleGroup(groupId: string) {
+    setCollapsedGroups((prev) => ({ ...prev, [groupId]: !prev[groupId] }));
+  }
 
   return (
     <aside className={`sidebar ${collapsed ? 'is-collapsed' : ''}`} data-collapsed={collapsed}>
@@ -61,29 +82,54 @@ function Sidebar({ activeSection, developerMode, onSectionChange }: SidebarProps
       </button>
 
       <nav className="sidebar-nav" aria-label="主菜单">
-        {menuItems.map((item) => {
-          const Icon = navigationIcons[item.id];
-          const isActive = item.id === activeSection;
-          const button = (
-            <button
-              key={item.id}
-              type="button"
-              className={`nav-item ${isActive ? 'is-active' : ''}`}
-              onClick={() => onSectionChange(item.id)}
-              aria-label={item.label}
-              aria-current={isActive ? 'page' : undefined}
-            >
-              <span className="nav-icon" aria-hidden="true">
-                <Icon />
-              </span>
-              <span className="nav-copy">
-                <strong>{item.label}</strong>
-                <small>{item.description}</small>
-              </span>
-            </button>
-          );
+        {menuGroups.map((group) => {
+          const isGroupCollapsed = Boolean(collapsedGroups[group.id]);
+          const isActiveGroup = group.items.some((item) => item.id === activeSection);
 
-          return collapsed ? wrapTooltip(item.label, button) : button;
+          return (
+            <div className={`nav-group ${isGroupCollapsed ? 'is-folded' : ''}${isActiveGroup ? ' has-active' : ''}`} key={group.id}>
+              {!collapsed && (
+                <button
+                  type="button"
+                  className="nav-group-trigger"
+                  onClick={() => toggleGroup(group.id)}
+                  aria-expanded={!isGroupCollapsed}
+                  aria-controls={`nav-group-${group.id}`}
+                >
+                  <span>{group.label}</span>
+                  <ChevronIcon className={isGroupCollapsed ? 'rotate-270' : 'rotate-90'} />
+                </button>
+              )}
+              {(!isGroupCollapsed || collapsed) && (
+                <div className="nav-group-items" id={`nav-group-${group.id}`}>
+                  {group.items.map((item) => {
+                    const Icon = navigationIcons[item.id];
+                    const isActive = item.id === activeSection;
+                    const button = (
+                      <button
+                        key={item.id}
+                        type="button"
+                        className={`nav-item ${isActive ? 'is-active' : ''}`}
+                        onClick={() => onSectionChange(item.id)}
+                        aria-label={item.label}
+                        aria-current={isActive ? 'page' : undefined}
+                      >
+                        <span className="nav-icon" aria-hidden="true">
+                          <Icon />
+                        </span>
+                        <span className="nav-copy">
+                          <strong>{item.label}</strong>
+                          <small>{item.description}</small>
+                        </span>
+                      </button>
+                    );
+
+                    return collapsed ? wrapTooltip(item.label, button) : button;
+                  })}
+                </div>
+              )}
+            </div>
+          );
         })}
       </nav>
 
@@ -158,6 +204,28 @@ function ArchiveIcon(props: SVGProps<SVGSVGElement>) {
       <path d="M5 7.5h14v12H5z" />
       <path d="M4 4.5h16v3H4z" />
       <path d="M9 11.2h6" />
+    </svg>
+  );
+}
+
+function CertificateIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" {...props}>
+      <path d="M6.5 4.5h11v15h-11z" />
+      <path d="M9 8h6" />
+      <path d="M9 11h6" />
+      <path d="M9 14h3.5" />
+      <path d="m15.2 16.2 1.1 1.1 2-2.3" />
+    </svg>
+  );
+}
+
+function CodeIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" {...props}>
+      <path d="m9 8-4 4 4 4" />
+      <path d="m15 8 4 4-4 4" />
+      <path d="m13 5-2 14" />
     </svg>
   );
 }

--- a/client/src/features/code-generation/pages/CodeGenerationPage.tsx
+++ b/client/src/features/code-generation/pages/CodeGenerationPage.tsx
@@ -1,0 +1,371 @@
+import { useEffect, useMemo, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { useToast } from '../../../shared/ui/ToastProvider';
+import type { CodeGenerationState } from '../types';
+
+const categoryOrder = ['全部', '入口', '路由', '页面', '业务服务', '状态数据', '组件', '通用能力', '源码', '样式'];
+
+interface AiCopyrightNoticeBlock {
+  heading?: string;
+  paragraphs?: string[];
+  list?: string[];
+}
+
+interface AiCopyrightNoticeSection {
+  title: string;
+  blocks: AiCopyrightNoticeBlock[];
+}
+
+const aiCopyrightNoticeSections: AiCopyrightNoticeSection[] = [
+  {
+    title: '一、法律底层判定依据',
+    blocks: [
+      {
+        heading: '《著作权法》保护前提：人类智力独创性成果',
+        paragraphs: [
+          '只有以人类为主导创作、AI 仅作为辅助工具的代码，才具备著作权保护资格；完全无人工干预、AI 自主生成的代码，不属于著作权法保护客体，无法登记软著。',
+        ],
+      },
+      {
+        heading: '2026 年 3 月 15 日版权中心硬性诚信承诺制度（核心红线）',
+        paragraphs: ['新版申请表签章页强制要求手抄承诺原文：'],
+        list: [
+          '本软件确系人的独立开发，未使用 AI 开发编写代码、撰写文档或生成登记申请材料。如有失实或欺骗，自愿列入版权登记失信名单、关联个人征信并承担全部法律责任。',
+          '必须经办人手写抄写、签字、填写身份证号，企业额外加盖公章；代理机构不能代签、代抄。',
+          '隐瞒 AI 生成代码属于虚假申报，查实后果：撤销已下发软著证书、公示失信记录、限制后续知识产权申报、追究民事 / 行政责任，批量造假会从严惩戒。',
+        ],
+      },
+    ],
+  },
+  {
+    title: '二、两类场景区分审核标准',
+    blocks: [
+      {
+        heading: '场景 1：纯 AI 生成（无实质人工改造）→ 禁止申请软著',
+        paragraphs: ['满足以下任意一条直接驳回，申报属于违规：'],
+        list: [
+          '全程仅输入需求提示词，AI 输出代码后仅简单复制粘贴，无架构重构、逻辑改写、调试优化；',
+          '人工修改比例极低（行业实操阈值一般低于 30%），核心业务逻辑、整体框架完全由 AI 产出；',
+          '无完整人工开发链路、无需求文档、调试日志、迭代记录等人类创作证据。',
+        ],
+      },
+      {
+        heading: '场景 2：AI 辅助编程（人类主导，AI 仅工具）→ 可合规申请，但严禁虚假承诺',
+        paragraphs: ['1. 人工必须占据创作主导地位（独创性核心）'],
+        list: [
+          '人类负责：整体架构设计、业务需求定义、模块划分、算法选型、安全校验、整体集成；',
+          'AI 仅负责：片段代码补全、语法纠错、简单函数模板、注释辅助，不能产出软件核心逻辑。',
+          '实操安全比例：人工原创改造、自主编写内容占整体代码 ≥60%-70%，AI 片段仅作为填充辅助。',
+        ],
+      },
+      {
+        heading: '2. 不能直接签署“无 AI 参与”承诺书的处理方案',
+        paragraphs: ['官方没有设置“AI 参与勾选栏”，承诺书为统一固定文本，分两种合规操作：'],
+        list: [
+          '稳妥主流方案（推荐）：对 AI 生成片段进行大规模重构、重写、逻辑改造，最终交付登记的源代码、说明书全部由人工深度改写，整体视为人类独立开发，如实签署标准承诺书；同时内部永久留存 AI 交互记录、prompt、修改日志备查（应对事后抽查）。',
+          '高披露方案（AI 占比偏高时）：额外单独提交《AI 辅助开发情况说明》附件，写明使用的 AI 工具名称 / 版本、每部分 AI 生成范围、人工修改迭代记录、prompt 截图、调试记录，同步留存全部开发证据链；此方式审查周期更长，实质核查更严格。',
+        ],
+      },
+    ],
+  },
+  {
+    title: '三、AI 代码提交源代码材料硬性规范',
+    blocks: [
+      {
+        heading: '1. 代码注释必须人工完善（审核重点）',
+        paragraphs: ['AI 原生代码普遍缺少版权声明、业务逻辑解释，需人工逐条补全：'],
+        list: [
+          '每个文件头部添加人工版权、模块用途、开发人、开发日期注释；',
+          '核心函数、复杂算法块补充业务设计思路（而非简单参数说明）；',
+          '统一注释风格，消除 AI 生成的杂乱格式痕迹。',
+        ],
+      },
+      {
+        heading: '2. 源码格式统一标准（和普通软著一致）',
+        list: [
+          '提交前 30 页 + 后 30 页源码 PDF，每页去除空行后 ≥50 有效代码行；页眉标注软件全称 + 版本号；剔除第三方开源库、AI 模板冗余代码，只提交自主改造后的核心业务代码。',
+        ],
+      },
+      {
+        heading: '3. 禁止行为',
+        list: [
+          '直接上传 AI 一键生成未修改的源码、说明书；',
+          '用 AI 生成申报材料（申请表文字、功能描述、操作手册）；',
+          '掩盖开源依赖、AI 生成片段、抄袭痕迹；',
+          '拆分同一个 AI 项目批量注册多份软著（非正常登记打击范围）。',
+        ],
+      },
+    ],
+  },
+  {
+    title: '四、失信与抽查风险',
+    blocks: [
+      {
+        list: [
+          '审查采用有限实质审查，遇到代码风格高度模板化、逻辑同质化、批量申报的项目，会启动人工溯源核查；',
+          '后期可接受第三方投诉、行业抽检，一经查实隐瞒 AI 大量生成，已发证项目可能被撤销登记、证书作废、官网公示失信主体；',
+          '经办人记入版权诚信档案，影响企业高新、招投标、知识产权补贴资质；',
+          '情节严重涉及批量造假的，移交市场监管追责。',
+        ],
+      },
+    ],
+  },
+  {
+    title: '五、企业 / 个人实操合规步骤',
+    blocks: [
+      {
+        list: [
+          '开发阶段留存全证据：需求文档、架构图、AI 对话 prompt 截图、Git 迭代日志、调试记录、人工修改对比文件；',
+          '对 AI 产出代码做结构性重写、逻辑优化、注释重构，拉高人工原创占比；',
+          '撰写 500–1300 字详细软件功能说明（新版强制加长篇幅，杜绝 AI 模板套话），全部人工撰写；',
+          '评估 AI 占比：人工主导改写充足→正常签署标准承诺书；AI 占比较高→附加 AI 开发说明材料；',
+          '源代码、说明书全部人工校验排版、页眉页脚、命名规范，清除 AI 生成水印、冗余注释。',
+        ],
+      },
+    ],
+  },
+  {
+    title: '补充边界：AI 训练框架 / 模型本身',
+    blocks: [
+      {
+        list: [
+          '自研训练、人工调参、架构设计的 AI 模型软件（如大模型微调平台、推理部署程序），只要人类主导开发，完全可以正常申请软著；',
+          '单纯调用第三方现成大模型 API、仅做简单页面封装，独创性弱，通过率低，不建议盲目申报。',
+        ],
+      },
+    ],
+  },
+];
+
+function CodeGenerationPage() {
+  const { showToast } = useToast();
+  const [state, setState] = useState<CodeGenerationState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [category, setCategory] = useState('全部');
+  const [noticeOpen, setNoticeOpen] = useState(false);
+
+  const selectedSet = useMemo(() => new Set(state?.selectedPaths || []), [state?.selectedPaths]);
+  const files = useMemo(() => {
+    const candidates = state?.analysis?.candidates || [];
+    return category === '全部' ? candidates : candidates.filter((item) => item.category === category);
+  }, [category, state?.analysis]);
+  const categories = useMemo(() => {
+    const present = new Set((state?.analysis?.candidates || []).map((item) => item.category));
+    return categoryOrder.filter((item) => item === '全部' || present.has(item));
+  }, [state?.analysis]);
+  const canConfirm = Boolean(state?.project && state.selectedPaths.length);
+
+  useEffect(() => {
+    let mounted = true;
+    window.yibiao?.codeGeneration.loadState()
+      .then((nextState) => {
+        if (mounted) setState(nextState);
+      })
+      .catch((error) => showToast(error.message || '读取代码生成状态失败', 'error'))
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [showToast]);
+
+  async function handleSelectProject() {
+    try {
+      const result = await window.yibiao?.codeGeneration.selectProject();
+      if (!result?.success) {
+        if (result?.message) showToast(result.message, 'info');
+        return;
+      }
+      setState(result.state);
+      showToast('源码扫描完成，已自动选择一批候选文件', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '选择项目失败', 'error');
+    }
+  }
+
+  async function saveSelection(nextPaths: string[]) {
+    try {
+      const nextState = await window.yibiao?.codeGeneration.updateSelection({ selectedPaths: nextPaths });
+      if (nextState) setState(nextState);
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '保存选择失败', 'error');
+    }
+  }
+
+  function toggleFile(filePath: string) {
+    const next = new Set(selectedSet);
+    if (next.has(filePath)) {
+      next.delete(filePath);
+    } else {
+      next.add(filePath);
+    }
+    void saveSelection(Array.from(next));
+  }
+
+  async function handleConfirm() {
+    try {
+      const nextState = await window.yibiao?.codeGeneration.confirmSelection();
+      if (nextState) setState(nextState);
+      showToast('代码素材已确认，软著生成可以直接使用', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '确认失败', 'error');
+    }
+  }
+
+  async function handleClear() {
+    try {
+      const result = await window.yibiao?.codeGeneration.clear();
+      if (result) setState(result.state);
+      showToast('代码生成工作区已清空', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '清空失败', 'error');
+    }
+  }
+
+  if (loading) {
+    return <div className="code-generation-page"><div className="software-copyright-empty">正在读取代码素材状态...</div></div>;
+  }
+
+  return (
+    <div className="code-generation-page">
+      <section className="code-generation-header">
+        <div>
+          <span className="section-kicker">代码生成</span>
+          <h2>准备软著生成可复用的源码素材</h2>
+          <p>当前先用于扫描真实项目源码、确认用于软著的代码文件范围。后续软著生成可直接读取这里确认过的代码素材。</p>
+          <button type="button" className="code-generation-notice-link" onClick={() => setNoticeOpen(true)}>
+            关于AI生成软著的必看事项
+          </button>
+        </div>
+        <div className="software-copyright-header-actions">
+          <button type="button" className="secondary-action" onClick={handleSelectProject}>选择项目</button>
+          <button type="button" className="danger-action" onClick={handleClear}>清空</button>
+        </div>
+      </section>
+
+      <div className="code-generation-layout">
+        <main className="code-generation-main">
+          <section className="software-copyright-panel">
+            <div className="software-copyright-panel-head">
+              <div>
+                <span className="section-kicker">项目来源</span>
+                <h3>{state?.project?.name || '尚未选择项目'}</h3>
+              </div>
+              {state?.confirmed && <span className="code-generation-confirmed">已确认</span>}
+            </div>
+            {state?.analysis ? (
+              <div className="software-copyright-stats">
+                <article><span>源码文件</span><strong>{state.analysis.fileCount}</strong></article>
+                <article><span>源码行数</span><strong>{state.analysis.lineCount}</strong></article>
+                <article><span>已选文件</span><strong>{state.summary.selectedCount}</strong></article>
+                <article><span>预计页数</span><strong>{state.summary.estimatedPages}</strong></article>
+              </div>
+            ) : (
+              <div className="software-copyright-empty">请选择需要整理软著代码素材的项目目录。</div>
+            )}
+          </section>
+
+          <section className="software-copyright-panel code-generation-files-panel">
+            <div className="software-copyright-panel-head">
+              <div>
+                <span className="section-kicker">源码素材</span>
+                <h3>确认代码文件范围</h3>
+              </div>
+              <button type="button" className="primary-action" onClick={handleConfirm} disabled={!canConfirm}>确认素材</button>
+            </div>
+
+            <div className="code-generation-filter" role="tablist" aria-label="源码类型筛选">
+              {categories.map((item) => (
+                <button
+                  type="button"
+                  className={item === category ? 'is-active' : ''}
+                  onClick={() => setCategory(item)}
+                  key={item}
+                >
+                  {item}
+                </button>
+              ))}
+            </div>
+
+            {files.length ? (
+              <div className="code-generation-file-list">
+                {files.map((file) => (
+                  <label className="code-generation-file-row" key={file.path}>
+                    <input type="checkbox" checked={selectedSet.has(file.path)} onChange={() => toggleFile(file.path)} />
+                    <span className="code-generation-file-main">
+                      <strong>{file.path}</strong>
+                      <small>{file.category} · {file.extension} · {file.line_count} 行</small>
+                    </span>
+                  </label>
+                ))}
+              </div>
+            ) : (
+              <div className="software-copyright-empty">暂无可选源码文件。</div>
+            )}
+          </section>
+        </main>
+
+        <aside className="code-generation-side">
+          <section className="software-copyright-panel">
+            <div className="software-copyright-panel-head">
+              <div>
+                <span className="section-kicker">联动</span>
+                <h3>软著生成</h3>
+              </div>
+            </div>
+            <div className="code-generation-flow">
+              <span>选择项目并扫描源码</span>
+              <span>确认代码素材范围</span>
+              <span>软著生成选择代码生成结果</span>
+              <span>导出代码鉴别材料</span>
+            </div>
+            <p>确认后，软著生成会读取这里的项目目录和已选文件，不再重新自动挑选源码。</p>
+          </section>
+        </aside>
+      </div>
+
+      <Dialog.Root open={noticeOpen} onOpenChange={setNoticeOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="content-regenerate-modal" />
+          <Dialog.Content className="code-generation-ai-notice-card">
+            <div className="code-generation-ai-notice-head">
+              <div>
+                <Dialog.Title>关于AI生成软著的必看事项</Dialog.Title>
+                <Dialog.Description>
+                  申请前请先确认代码创作链路、人工改造比例和证据留存情况。具体登记要求请以官方最新受理口径为准。
+                </Dialog.Description>
+              </div>
+              <Dialog.Close className="detail-help-close" type="button" aria-label="关闭必看事项">×</Dialog.Close>
+            </div>
+
+            <div className="code-generation-ai-notice-body">
+              {aiCopyrightNoticeSections.map((section) => (
+                <section key={section.title}>
+                  <h3>{section.title}</h3>
+                  {section.blocks.map((block, index) => (
+                    <div className="code-generation-ai-notice-block" key={`${section.title}-${index}`}>
+                      {block.heading && <h4>{block.heading}</h4>}
+                      {block.paragraphs?.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
+                      {block.list && (
+                        <ul>
+                          {block.list.map((item) => <li key={item}>{item}</li>)}
+                        </ul>
+                      )}
+                    </div>
+                  ))}
+                </section>
+              ))}
+            </div>
+
+            <div className="code-generation-ai-notice-actions">
+              <Dialog.Close className="primary-action" type="button">我已知晓</Dialog.Close>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </div>
+  );
+}
+
+export default CodeGenerationPage;

--- a/client/src/features/code-generation/types.ts
+++ b/client/src/features/code-generation/types.ts
@@ -1,0 +1,47 @@
+export interface CodeGenerationProject {
+  name: string;
+  path: string;
+}
+
+export interface CodeGenerationFile {
+  path: string;
+  extension: string;
+  size: number;
+  line_count: number;
+  category: string;
+}
+
+export interface CodeGenerationAnalysis {
+  projectRoot: string;
+  projectName: string;
+  packageName: string;
+  packageVersion: string;
+  frameworks: string[];
+  languages: string[];
+  fileCount: number;
+  lineCount: number;
+  candidates: CodeGenerationFile[];
+}
+
+export interface CodeGenerationSummary {
+  selectedCount: number;
+  selectedLineCount: number;
+  estimatedPages: number;
+  selectedFiles: CodeGenerationFile[];
+}
+
+export interface CodeGenerationState {
+  project: CodeGenerationProject | null;
+  analysis: CodeGenerationAnalysis | null;
+  selectedPaths: string[];
+  confirmed: boolean;
+  confirmedAt: string;
+  updated_at: string;
+  summary: CodeGenerationSummary;
+}
+
+export interface CodeGenerationSelectResult {
+  success: boolean;
+  message?: string;
+  state: CodeGenerationState;
+}

--- a/client/src/features/software-copyright/pages/SoftwareCopyrightPage.tsx
+++ b/client/src/features/software-copyright/pages/SoftwareCopyrightPage.tsx
@@ -1,0 +1,1141 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { useEffect, useMemo, useState } from 'react';
+import { MarkdownEditor, MarkdownRenderer } from '../../../shared/ui';
+import { useToast } from '../../../shared/ui/ToastProvider';
+import type { SoftwareCopyrightCodeManifest, SoftwareCopyrightDraftFile, SoftwareCopyrightDraftValidationResult, SoftwareCopyrightFields, SoftwareCopyrightOptions, SoftwareCopyrightState } from '../types';
+
+const emptyFields: SoftwareCopyrightFields = {
+  softwareName: '',
+  shortName: '',
+  version: 'V1.0',
+  category: '应用软件',
+  developmentCompletedDate: '',
+  developmentMode: '单独开发',
+  softwareDescription: '原创',
+  publishStatus: '未发表',
+  firstPublishDate: '',
+  copyrightOwner: '',
+  rightsScope: '全部权利',
+  rightsAcquisition: '原始取得',
+  developmentHardware: '',
+  runningHardware: '',
+  developmentOs: '',
+  developmentTools: '',
+  runningPlatform: '',
+  runtimeSupport: '',
+  programmingLanguage: '',
+  sourceLineCount: '',
+  developmentPurpose: '',
+  industry: '',
+  mainFunctions: '',
+  technicalFeatures: '',
+  pageCount: '',
+};
+
+const requiredFields: Array<keyof SoftwareCopyrightFields> = [
+  'softwareName',
+  'version',
+  'developmentCompletedDate',
+  'copyrightOwner',
+  'developmentHardware',
+  'runningHardware',
+  'developmentOs',
+  'developmentTools',
+  'runningPlatform',
+  'runtimeSupport',
+  'programmingLanguage',
+  'developmentPurpose',
+  'industry',
+];
+
+const basicFieldRows: Array<{ key: keyof SoftwareCopyrightFields; label: string; placeholder?: string }> = [
+  { key: 'softwareName', label: '软件全称', placeholder: '例如：禹都AI投标助手软件' },
+  { key: 'shortName', label: '软件简称', placeholder: '可选' },
+  { key: 'version', label: '版本号', placeholder: 'V1.0' },
+  { key: 'category', label: '软件分类', placeholder: '应用软件' },
+  { key: 'developmentCompletedDate', label: '开发完成日期', placeholder: 'YYYY-MM-DD' },
+  { key: 'developmentMode', label: '开发方式', placeholder: '单独开发' },
+  { key: 'softwareDescription', label: '软件说明', placeholder: '原创' },
+  { key: 'publishStatus', label: '发表状态', placeholder: '未发表' },
+  { key: 'firstPublishDate', label: '首次发表日期', placeholder: '未发表可留空' },
+  { key: 'copyrightOwner', label: '著作权人', placeholder: '国家/省市/类型/姓名或单位/证件信息' },
+];
+
+const environmentFieldRows: Array<{ key: keyof SoftwareCopyrightFields; label: string; placeholder?: string }> = [
+  { key: 'developmentHardware', label: '开发硬件环境', placeholder: '≤50字符，例如 Intel i7/16GB/512GB' },
+  { key: 'runningHardware', label: '运行硬件环境', placeholder: '≤50字符，可沿用开发硬件' },
+  { key: 'developmentOs', label: '开发操作系统', placeholder: '例如 Windows 11 / macOS 15' },
+  { key: 'developmentTools', label: '开发环境 / 工具', placeholder: '开发环境: Windows 11/开发工具: VS Code' },
+  { key: 'runningPlatform', label: '运行平台 / 操作系统', placeholder: '例如 Windows 10 及以上' },
+  { key: 'runtimeSupport', label: '运行支撑环境', placeholder: '例如 Electron、Node.js、Chromium' },
+  { key: 'programmingLanguage', label: '编程语言', placeholder: 'TypeScript、JavaScript' },
+  { key: 'sourceLineCount', label: '源程序量', placeholder: '纯数字' },
+  { key: 'developmentPurpose', label: '开发目的', placeholder: '≤50字符' },
+  { key: 'industry', label: '面向领域 / 行业', placeholder: '≤50字符' },
+];
+
+const defaultExportItems: SoftwareCopyrightOptions['exportItems'] = {
+  application: true,
+  manual: true,
+  code: true,
+  report: true,
+};
+
+const defaultOptions: SoftwareCopyrightOptions = {
+  sourceMode: 'project',
+  screenshotMode: 'skip',
+  useAiImages: false,
+  codeExcludedPaths: [],
+  codeIncludedPaths: [],
+  exportItems: defaultExportItems,
+};
+
+const exportItemRows: Array<{ key: keyof SoftwareCopyrightOptions['exportItems']; label: string }> = [
+  { key: 'application', label: '申请表 TXT' },
+  { key: 'manual', label: '操作手册 DOCX' },
+  { key: 'code', label: '代码材料 DOCX' },
+  { key: 'report', label: '生成报告' },
+];
+
+function summarizeStatItems(items: string[] | undefined, limit = 4) {
+  const values = (items || []).filter(Boolean);
+  if (!values.length) {
+    return { text: '未识别', title: '未识别' };
+  }
+  const visible = values.slice(0, limit);
+  return {
+    text: values.length > limit ? `${visible.join('、')} 等 ${values.length} 项` : visible.join('、'),
+    title: values.join('、'),
+  };
+}
+
+function getCodeMaterialRiskTips(manifest: SoftwareCopyrightCodeManifest | null, includedPaths: string[], excludedPaths: string[]) {
+  if (!manifest) return [];
+  const tips: string[] = [];
+  const totalPages = Number(manifest.total_pages || 0);
+  const fileCount = manifest.files?.length || 0;
+  const categoryCount = Object.keys(manifest.category_summary || {}).length;
+  const manifestIncluded = manifest.included_paths || [];
+  const manifestExcluded = manifest.excluded_paths || [];
+  const hasPendingInclude = includedPaths.some((filePath) => !manifestIncluded.includes(filePath));
+  const hasPendingExclude = excludedPaths.some((filePath) => !manifestExcluded.includes(filePath));
+
+  if (totalPages < 60) {
+    tips.push('当前不足 60 页，将导出全部代码材料；如当地要求前后各 30 页，可补充更多核心源码后重新抽取。');
+  } else if (totalPages > 120) {
+    tips.push('当前页数较多，前 30 页和后 30 页之间会跳过较大段源码，建议排除低代表性文件或补充更核心文件后重新抽取。');
+  } else if (totalPages > 90) {
+    tips.push('当前页数偏多，请重点核对前 30 页和后 30 页是否覆盖主要功能入口、页面和业务服务。');
+  }
+
+  if (fileCount > 0 && fileCount < 5) {
+    tips.push('当前源码文件数量较少，建议确认是否已经覆盖入口、页面、业务服务和数据处理等关键模块。');
+  }
+  if (categoryCount > 0 && categoryCount < 3) {
+    tips.push('当前文件类别覆盖较窄，可考虑补充页面、服务、状态数据或通用能力文件。');
+  }
+  if (hasPendingInclude || hasPendingExclude) {
+    tips.push('补充或排除列表已有变更，请点击“重新抽取”后再确认草稿。');
+  }
+  return tips;
+}
+
+function SoftwareCopyrightPage() {
+  const { showToast } = useToast();
+  const [state, setState] = useState<SoftwareCopyrightState | null>(null);
+  const [fields, setFields] = useState<SoftwareCopyrightFields>(emptyFields);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [activeDraftKey, setActiveDraftKey] = useState<string>('');
+  const [draftFile, setDraftFile] = useState<SoftwareCopyrightDraftFile | null>(null);
+  const [draftContent, setDraftContent] = useState('');
+  const [draftLoading, setDraftLoading] = useState(false);
+  const [draftSaving, setDraftSaving] = useState(false);
+  const [draftDirty, setDraftDirty] = useState(false);
+  const [draftViewMode, setDraftViewMode] = useState<'edit' | 'preview'>('edit');
+  const [validation, setValidation] = useState<SoftwareCopyrightDraftValidationResult | null>(null);
+  const [validating, setValidating] = useState(false);
+  const [codeManifest, setCodeManifest] = useState<SoftwareCopyrightCodeManifest | null>(null);
+  const [codeManifestLoading, setCodeManifestLoading] = useState(false);
+  const [regeneratingCode, setRegeneratingCode] = useState(false);
+  const [exportConfirmOpen, setExportConfirmOpen] = useState(false);
+  const [complianceNoticeOpen, setComplianceNoticeOpen] = useState(false);
+  const [codeCandidateKeyword, setCodeCandidateKeyword] = useState('');
+
+  const task = state?.task;
+  const isRunning = task?.status === 'running';
+  const missingFields = useMemo(
+    () => requiredFields.filter((key) => !String(fields[key] || '').trim()),
+    [fields],
+  );
+  const sourceMode = state?.options.sourceMode || 'project';
+  const codeExcludedPaths = state?.options.codeExcludedPaths || [];
+  const codeIncludedPaths = state?.options.codeIncludedPaths || [];
+  const hasSource = sourceMode === 'code-generation' ? Boolean(state?.codeGeneration?.available) : Boolean(state?.project);
+  const canGenerateDraft = Boolean(hasSource && fields.softwareName.trim() && fields.version.trim() && !isRunning);
+  const hasDrafts = Boolean(state?.drafts && Object.keys(state.drafts).length > 0);
+  const canConfirmDraft = Boolean(hasDrafts && !state?.draftConfirmed && !isRunning);
+  const exportItems = { ...defaultExportItems, ...(state?.options.exportItems || {}) };
+  const hasExportItem = Object.values(exportItems).some(Boolean);
+  const canExportFinal = Boolean(hasDrafts && state?.draftConfirmed && hasExportItem && !isRunning);
+  const canValidateDraft = Boolean(hasDrafts && !isRunning);
+  const canRegenerateCodeMaterial = Boolean(hasDrafts && hasSource && !isRunning && !draftDirty && !regeneratingCode);
+  const draftEntries = useMemo(() => Object.entries(state?.drafts || {}), [state?.drafts]);
+  const frameworkSummary = useMemo(() => summarizeStatItems(state?.analysis?.frameworks, 4), [state?.analysis?.frameworks]);
+  const languageSummary = useMemo(() => summarizeStatItems(state?.analysis?.languages, 5), [state?.analysis?.languages]);
+  const codeMaterialReady = Boolean(codeManifest && codeManifest.total_pages >= 60 && codeManifest.mode === 'front30_back30');
+  const codeManifestFiles = useMemo(() => codeManifest?.files?.slice(0, 12) || [], [codeManifest?.files]);
+  const codeRiskTips = useMemo(() => getCodeMaterialRiskTips(codeManifest, codeIncludedPaths, codeExcludedPaths), [codeExcludedPaths, codeIncludedPaths, codeManifest]);
+  const selectedExportLabels = useMemo(
+    () => exportItemRows.filter((item) => exportItems[item.key]).map((item) => item.label),
+    [exportItems],
+  );
+  const codeCandidateFiles = useMemo(() => {
+    const selectedPaths = new Set([...(codeManifest?.files || []).map((file) => file.path), ...codeIncludedPaths]);
+    const keyword = codeCandidateKeyword.trim().toLowerCase();
+    return (state?.analysis?.candidates || [])
+      .filter((file) => !selectedPaths.has(file.path) && !codeExcludedPaths.includes(file.path))
+      .filter((file) => !keyword || file.path.toLowerCase().includes(keyword) || file.category.toLowerCase().includes(keyword))
+      .slice(0, 8);
+  }, [codeCandidateKeyword, codeExcludedPaths, codeIncludedPaths, codeManifest?.files, state?.analysis?.candidates]);
+
+  useEffect(() => {
+    let mounted = true;
+    window.yibiao?.softwareCopyright.loadState()
+      .then((nextState) => {
+        if (!mounted) return;
+        setState(nextState);
+        setFields({ ...emptyFields, ...nextState.fields });
+      })
+      .catch((error) => showToast(error.message || '读取软著生成状态失败', 'error'))
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+
+    const unsubscribe = window.yibiao?.softwareCopyright.onEvent((nextState) => {
+      setState(nextState);
+      setFields((prev) => ({ ...prev, ...nextState.fields }));
+    });
+
+    return () => {
+      mounted = false;
+      unsubscribe?.();
+    };
+  }, [showToast]);
+
+  useEffect(() => {
+    if (!draftEntries.length) {
+      setActiveDraftKey('');
+      setDraftFile(null);
+      setDraftContent('');
+      setDraftDirty(false);
+      return;
+    }
+    if (!activeDraftKey || !state?.drafts?.[activeDraftKey]) {
+      setActiveDraftKey(draftEntries[0][0]);
+    }
+  }, [activeDraftKey, draftEntries, state?.drafts]);
+
+  useEffect(() => {
+    let mounted = true;
+    if (!activeDraftKey) return undefined;
+
+    setDraftLoading(true);
+    window.yibiao?.softwareCopyright.readDraft(activeDraftKey)
+      .then((file) => {
+        if (!mounted) return;
+        setDraftFile(file);
+        setDraftContent(file.content);
+        setDraftDirty(false);
+      })
+      .catch((error) => {
+        if (mounted) showToast(error instanceof Error ? error.message : '读取草稿失败', 'error');
+      })
+      .finally(() => {
+        if (mounted) setDraftLoading(false);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [activeDraftKey, showToast]);
+
+  useEffect(() => {
+    let mounted = true;
+    if (!hasDrafts) {
+      setCodeManifest(null);
+      return undefined;
+    }
+
+    setCodeManifestLoading(true);
+    window.yibiao?.softwareCopyright.readCodeManifest()
+      .then((manifest) => {
+        if (mounted) setCodeManifest(manifest);
+      })
+      .catch((error) => {
+        if (mounted) showToast(error instanceof Error ? error.message : '读取代码材料清单失败', 'error');
+      })
+      .finally(() => {
+        if (mounted) setCodeManifestLoading(false);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [hasDrafts, state?.draftDir, state?.task?.status, showToast]);
+
+  async function handleSelectProject() {
+    try {
+      const result = await window.yibiao?.softwareCopyright.selectProject();
+      if (!result?.success) {
+        if (result?.message) showToast(result.message, 'info');
+        return;
+      }
+      setState(result.state);
+      setFields({ ...emptyFields, ...result.state.fields });
+      showToast('项目分析完成', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '选择项目失败', 'error');
+    }
+  }
+
+  async function handleSaveFields() {
+    setSaving(true);
+    try {
+      const nextState = await window.yibiao?.softwareCopyright.saveFields(fields);
+      if (nextState) {
+        setState(nextState);
+      }
+      showToast('字段已保存', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '保存字段失败', 'error');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleToggleAiImages(checked: boolean) {
+    const options = { ...(state?.options || defaultOptions), useAiImages: checked, screenshotMode: checked ? 'ai' as const : 'skip' as const };
+    const nextState = await window.yibiao?.softwareCopyright.saveOptions(options);
+    if (nextState) setState(nextState);
+  }
+
+  async function handleSourceModeChange(nextSourceMode: 'project' | 'code-generation') {
+    const options = { ...(state?.options || defaultOptions), sourceMode: nextSourceMode };
+    const nextState = await window.yibiao?.softwareCopyright.saveOptions(options);
+    if (nextState) setState(nextState);
+  }
+
+  async function handleToggleExportItem(key: keyof SoftwareCopyrightOptions['exportItems'], checked: boolean) {
+    const nextExportItems = { ...exportItems, [key]: checked };
+    const nextState = await window.yibiao?.softwareCopyright.saveOptions({
+      ...(state?.options || defaultOptions),
+      exportItems: nextExportItems,
+    });
+    if (nextState) setState(nextState);
+  }
+
+  async function handleGenerateDraft() {
+    if (!canGenerateDraft) {
+      showToast(sourceMode === 'code-generation' ? '请先在代码生成中确认素材，并确认软件全称和版本号' : '请先选择项目，并至少确认软件全称和版本号', 'info');
+      return;
+    }
+    if (missingFields.length) {
+      showToast('仍有登记字段未补全，生成结果会保留“待用户确认”提示', 'info');
+    }
+    await handleSaveFields();
+    try {
+      setValidation(null);
+      await window.yibiao?.softwareCopyright.startGeneration({ fields, useAiImages: Boolean(state?.options.useAiImages), sourceMode, codeExcludedPaths, codeIncludedPaths });
+      showToast('软著草稿生成已开始', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '启动草稿生成失败', 'error');
+    }
+  }
+
+  async function handleConfirmDraft() {
+    if (draftDirty) {
+      showToast('草稿内容已修改，请先保存后再确认', 'info');
+      return;
+    }
+    const validationResult = await handleValidateDraft(true);
+    if (!validationResult?.valid) {
+      showToast('草稿检查未通过，请先处理缺失项', 'error');
+      return;
+    }
+    try {
+      const nextState = await window.yibiao?.softwareCopyright.confirmDraft();
+      if (nextState) setState(nextState);
+      showToast('草稿已确认，可以导出正式资料', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '确认草稿失败', 'error');
+    }
+  }
+
+  async function handleExportFinal() {
+    if (!hasExportItem) {
+      showToast('请至少选择一种正式资料导出项', 'info');
+      return;
+    }
+    setExportConfirmOpen(true);
+  }
+
+  async function handleConfirmExportFinal() {
+    try {
+      setExportConfirmOpen(false);
+      await window.yibiao?.softwareCopyright.exportFinal({ exportItems });
+      showToast('正式资料导出已开始', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '导出正式资料失败', 'error');
+    }
+  }
+
+  async function handleOpenOutputDir() {
+    try {
+      await window.yibiao?.softwareCopyright.openOutputDir();
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '打开输出目录失败', 'error');
+    }
+  }
+
+  async function handleClear() {
+    try {
+      const result = await window.yibiao?.softwareCopyright.clear();
+      if (!result) return;
+      setState(result.state);
+      setFields({ ...emptyFields, ...result.state.fields });
+      setDraftFile(null);
+      setDraftContent('');
+      setDraftDirty(false);
+      setValidation(null);
+      setCodeManifest(null);
+      showToast('软著生成工作区已清空', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '清空失败', 'error');
+    }
+  }
+
+  function updateField(key: keyof SoftwareCopyrightFields, value: string) {
+    setFields((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function handleDraftContentChange(value: string) {
+    setDraftContent(value);
+    setDraftDirty(value !== (draftFile?.content || ''));
+  }
+
+  function handleSelectDraft(nextKey: string) {
+    if (nextKey === activeDraftKey) return;
+    if (draftDirty) {
+      showToast('当前草稿有未保存修改，请先保存后再切换', 'info');
+      return;
+    }
+    setActiveDraftKey(nextKey);
+  }
+
+  async function handleSaveDraft() {
+    if (!activeDraftKey || !draftDirty) return;
+    setDraftSaving(true);
+    try {
+      const result = await window.yibiao?.softwareCopyright.saveDraft({ key: activeDraftKey, content: draftContent });
+      if (result) {
+        setDraftFile(result);
+        setDraftContent(result.content);
+        setDraftDirty(false);
+        setState(result.state);
+        setValidation(null);
+      }
+      showToast('草稿已保存，需重新确认后再导出', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '保存草稿失败', 'error');
+    } finally {
+      setDraftSaving(false);
+    }
+  }
+
+  async function handleToggleCodeExcludedPath(filePath: string, checked: boolean) {
+    const nextExcludedPaths = checked
+      ? Array.from(new Set([...codeExcludedPaths, filePath]))
+      : codeExcludedPaths.filter((item) => item !== filePath);
+    const nextIncludedPaths = checked ? codeIncludedPaths.filter((item) => item !== filePath) : codeIncludedPaths;
+    try {
+      const nextState = await window.yibiao?.softwareCopyright.saveOptions({
+        ...(state?.options || defaultOptions),
+        codeExcludedPaths: nextExcludedPaths,
+        codeIncludedPaths: nextIncludedPaths,
+      });
+      if (nextState) setState(nextState);
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '更新排除文件失败', 'error');
+    }
+  }
+
+  async function handleToggleCodeIncludedPath(filePath: string, checked: boolean) {
+    const nextIncludedPaths = checked
+      ? Array.from(new Set([...codeIncludedPaths, filePath]))
+      : codeIncludedPaths.filter((item) => item !== filePath);
+    const nextExcludedPaths = checked ? codeExcludedPaths.filter((item) => item !== filePath) : codeExcludedPaths;
+    try {
+      const nextState = await window.yibiao?.softwareCopyright.saveOptions({
+        ...(state?.options || defaultOptions),
+        codeExcludedPaths: nextExcludedPaths,
+        codeIncludedPaths: nextIncludedPaths,
+      });
+      if (nextState) setState(nextState);
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '更新补充文件失败', 'error');
+    }
+  }
+
+  async function handleRegenerateCodeMaterial() {
+    if (draftDirty) {
+      showToast('当前草稿有未保存修改，请先保存后再重新抽取代码材料', 'info');
+      return;
+    }
+    setRegeneratingCode(true);
+    try {
+      const savedState = await window.yibiao?.softwareCopyright.saveFields(fields);
+      if (savedState) setState(savedState);
+      const result = await window.yibiao?.softwareCopyright.regenerateCodeMaterial({ fields, sourceMode, codeExcludedPaths, codeIncludedPaths });
+      if (result) {
+        setState(result.state);
+        setFields({ ...emptyFields, ...result.state.fields });
+        setCodeManifest(result.manifest);
+        setValidation(null);
+        if (activeDraftKey && activeDraftKey.startsWith('code')) {
+          setActiveDraftKey('codeManifest');
+        }
+      }
+      showToast('代码材料已重新抽取，请重新检查并确认草稿', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '重新抽取代码材料失败', 'error');
+    } finally {
+      setRegeneratingCode(false);
+    }
+  }
+
+  async function handleValidateDraft(silent = false) {
+    if (!canValidateDraft) return null;
+    setValidating(true);
+    try {
+      const result = await window.yibiao?.softwareCopyright.validateDraft();
+      if (result) {
+        setValidation(result);
+        if (!silent) {
+          showToast(result.valid ? '草稿检查通过' : `草稿检查发现 ${result.issues.length} 项问题`, result.valid ? 'success' : 'error');
+        }
+      }
+      return result || null;
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '草稿检查失败', 'error');
+      return null;
+    } finally {
+      setValidating(false);
+    }
+  }
+
+  if (loading) {
+    return <div className="software-copyright-page"><div className="software-copyright-empty">正在读取软著生成状态...</div></div>;
+  }
+
+  return (
+    <div className="software-copyright-page">
+      <section className="software-copyright-header">
+        <div>
+          <span className="section-kicker">软著生成</span>
+          <h2>生成申请表信息、操作手册和代码鉴别材料</h2>
+          <p>文本生成使用设置中的文本模型；示意图可选使用设置中的生图模型。代码材料只从所选项目真实源码中抽取。</p>
+          <div className="software-copyright-format-notice">
+            导出材料格式需根据当地受理要求人为微调，请勿直接使用！
+          </div>
+          <button type="button" className="software-copyright-compliance-link" onClick={() => setComplianceNoticeOpen(true)}>
+            软著AI合规提醒
+          </button>
+        </div>
+        <div className="software-copyright-header-actions">
+          <button type="button" className="secondary-action" onClick={handleSelectProject} disabled={isRunning}>选择项目</button>
+          <button type="button" className="secondary-action" onClick={handleOpenOutputDir}>打开输出目录</button>
+          <button type="button" className="danger-action" onClick={handleClear} disabled={isRunning}>清空</button>
+        </div>
+      </section>
+
+      <div className="software-copyright-layout">
+        <main className="software-copyright-main">
+          <section className="software-copyright-panel">
+            <div className="software-copyright-panel-head">
+              <div>
+                <span className="section-kicker">项目来源</span>
+                <h3>{sourceMode === 'code-generation' ? state?.codeGeneration?.project?.name || '尚未确认代码素材' : state?.project?.name || '尚未选择项目'}</h3>
+              </div>
+              {sourceMode === 'code-generation'
+                ? state?.codeGeneration?.project && <span className="demo-soft-pill">{state.codeGeneration.project.path}</span>
+                : state?.project && <span className="demo-soft-pill">{state.project.path}</span>}
+            </div>
+            <div className="software-copyright-source-switch">
+              <button
+                type="button"
+                className={sourceMode === 'project' ? 'is-active' : ''}
+                onClick={() => void handleSourceModeChange('project')}
+                disabled={isRunning}
+              >
+                选择项目目录
+              </button>
+              <button
+                type="button"
+                className={sourceMode === 'code-generation' ? 'is-active' : ''}
+                onClick={() => void handleSourceModeChange('code-generation')}
+                disabled={isRunning || !state?.codeGeneration?.available}
+              >
+                使用代码生成结果
+              </button>
+            </div>
+            {sourceMode === 'project' && state?.analysis ? (
+              <div className="software-copyright-stats">
+                <article><span>源码文件</span><strong>{state.analysis.fileCount}</strong></article>
+                <article><span>源码行数</span><strong>{state.analysis.lineCount}</strong></article>
+                <article className="is-text"><span>技术栈</span><strong title={frameworkSummary.title}>{frameworkSummary.text}</strong></article>
+                <article className="is-text"><span>语言</span><strong title={languageSummary.title}>{languageSummary.text}</strong></article>
+              </div>
+            ) : sourceMode === 'code-generation' && state?.codeGeneration?.available ? (
+              <div className="software-copyright-stats">
+                <article><span>已选文件</span><strong>{state.codeGeneration.summary?.selectedCount || 0}</strong></article>
+                <article><span>素材行数</span><strong>{state.codeGeneration.summary?.selectedLineCount || 0}</strong></article>
+                <article><span>预计页数</span><strong>{state.codeGeneration.summary?.estimatedPages || 0}</strong></article>
+                <article><span>确认时间</span><strong>{state.codeGeneration.confirmedAt ? new Date(state.codeGeneration.confirmedAt).toLocaleString() : '已确认'}</strong></article>
+              </div>
+            ) : (
+              <div className="software-copyright-empty">{sourceMode === 'code-generation' ? '请先到代码生成页面选择项目并确认代码素材。' : '请选择需要申请软著的软件项目目录。'}</div>
+            )}
+          </section>
+
+          <section className="software-copyright-panel">
+            <div className="software-copyright-panel-head">
+              <div>
+                <span className="section-kicker">代码材料</span>
+                <h3>抽取清单预览</h3>
+              </div>
+              <div className="software-copyright-code-actions">
+                {codeManifest && (
+                  <em className={`software-copyright-task-status is-${codeMaterialReady ? 'success' : 'running'}`}>
+                    {codeMaterialReady ? '满足条件' : '需核对'}
+                  </em>
+                )}
+                <button
+                  type="button"
+                  className="secondary-action"
+                  onClick={handleRegenerateCodeMaterial}
+                  disabled={!canRegenerateCodeMaterial}
+                >
+                  {regeneratingCode ? '抽取中...' : '重新抽取'}
+                </button>
+              </div>
+            </div>
+            {codeManifestLoading ? (
+              <div className="software-copyright-empty">正在读取代码材料清单...</div>
+            ) : codeManifest ? (
+              <div className="software-copyright-code-manifest">
+                <div className="software-copyright-code-summary">
+                  <article>
+                    <span>材料页数</span>
+                    <strong>{codeManifest.total_pages}</strong>
+                  </article>
+                  <article>
+                    <span>材料行数</span>
+                    <strong>{codeManifest.material_line_count}</strong>
+                  </article>
+                  <article>
+                    <span>源码文件</span>
+                    <strong>{codeManifest.files?.length || 0}</strong>
+                  </article>
+                  <article>
+                    <span>切页行数</span>
+                    <strong>{codeManifest.lines_per_page}</strong>
+                  </article>
+                </div>
+                <div className={`software-copyright-code-status is-${codeMaterialReady ? 'ready' : 'review'}`}>
+                  {codeMaterialReady
+                    ? '当前已满足前30页+后30页代码材料条件。'
+                    : codeManifest.total_pages >= 60
+                      ? '当前页数已超过60页，请核对前30页和后30页内容是否具有代表性。'
+                      : '当前不足60页，将导出全部代码材料，请根据受理要求人工核对。'}
+                </div>
+                {codeRiskTips.length > 0 && (
+                  <div className="software-copyright-code-risk">
+                    <strong>材料提示</strong>
+                    <ul>
+                      {codeRiskTips.map((tip) => <li key={tip}>{tip}</li>)}
+                    </ul>
+                  </div>
+                )}
+                <div className="software-copyright-code-tags">
+                  {Object.entries(codeManifest.category_summary || {}).map(([category, count]) => (
+                    <span key={category}>{category} {count}</span>
+                  ))}
+                </div>
+                <div className="software-copyright-code-strategy">
+                  <strong>选择策略</strong>
+                  <span>{codeManifest.selection_strategy ? formatSelectionStrategy(codeManifest.selection_strategy) : '默认源码抽取'}</span>
+                </div>
+                {codeExcludedPaths.length > 0 && (
+                  <div className="software-copyright-code-excluded">
+                    <strong>已标记排除</strong>
+                    <div>
+                      {codeExcludedPaths.map((filePath) => (
+                        <button
+                          type="button"
+                          onClick={() => void handleToggleCodeExcludedPath(filePath, false)}
+                          disabled={isRunning || regeneratingCode}
+                          title={filePath}
+                          key={filePath}
+                        >
+                          {filePath}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                <div className="software-copyright-code-picker">
+                  <div className="software-copyright-code-picker-head">
+                    <strong>手动补充文件</strong>
+                    <input
+                      value={codeCandidateKeyword}
+                      onChange={(event) => setCodeCandidateKeyword(event.target.value)}
+                      placeholder="搜索候选源码"
+                      disabled={isRunning || regeneratingCode}
+                    />
+                  </div>
+                  {codeIncludedPaths.length > 0 && (
+                    <div className="software-copyright-code-included">
+                      {codeIncludedPaths.map((filePath) => (
+                        <button
+                          type="button"
+                          onClick={() => void handleToggleCodeIncludedPath(filePath, false)}
+                          disabled={isRunning || regeneratingCode}
+                          title={filePath}
+                          key={filePath}
+                        >
+                          {filePath}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  <div className="software-copyright-code-candidates">
+                    {codeCandidateFiles.length ? codeCandidateFiles.map((file) => (
+                      <button
+                        type="button"
+                        onClick={() => void handleToggleCodeIncludedPath(file.path, true)}
+                        disabled={isRunning || regeneratingCode}
+                        title={file.path}
+                        key={file.path}
+                      >
+                        <span>{file.path}</span>
+                        <em>{file.category} · {file.line_count} 行</em>
+                      </button>
+                    )) : (
+                      <span>暂无可补充候选文件</span>
+                    )}
+                  </div>
+                  <span className="software-copyright-code-more">补充或排除文件后，点击“重新抽取”生效。</span>
+                </div>
+                <div className="software-copyright-code-table" role="table" aria-label="代码材料文件清单">
+                  <div className="software-copyright-code-row is-head" role="row">
+                    <span role="columnheader">排除</span>
+                    <span role="columnheader">文件</span>
+                    <span role="columnheader">类型</span>
+                    <span role="columnheader">行数</span>
+                  </div>
+                  {codeManifestFiles.map((file) => (
+                    <div className={`software-copyright-code-row ${codeExcludedPaths.includes(file.path) ? 'is-excluded' : ''}`} role="row" key={file.path}>
+                      <label role="cell" className="software-copyright-code-exclude-check" title={codeExcludedPaths.includes(file.path) ? '取消排除' : '排除该文件'}>
+                        <input
+                          type="checkbox"
+                          checked={codeExcludedPaths.includes(file.path)}
+                          onChange={(event) => void handleToggleCodeExcludedPath(file.path, event.target.checked)}
+                          disabled={isRunning || regeneratingCode}
+                        />
+                      </label>
+                      <span role="cell" title={file.path}>{file.path}</span>
+                      <span role="cell">{file.category}</span>
+                      <span role="cell">{file.source_line_count}</span>
+                    </div>
+                  ))}
+                </div>
+                {(codeManifest.files?.length || 0) > codeManifestFiles.length && (
+                  <span className="software-copyright-code-more">另有 {(codeManifest.files?.length || 0) - codeManifestFiles.length} 个文件，可在代码提取清单草稿中查看。勾选排除后，点击“重新抽取”生效。</span>
+                )}
+              </div>
+            ) : (
+              <div className="software-copyright-empty">生成草稿后会显示代码材料页数、文件类别和抽取清单；如源码发生变化，可单独重新抽取代码材料。</div>
+            )}
+          </section>
+
+          <section className="software-copyright-panel">
+            <div className="software-copyright-panel-head">
+              <div>
+                <span className="section-kicker">申请字段</span>
+                <h3>基础信息</h3>
+              </div>
+              <button type="button" className="secondary-action" onClick={handleSaveFields} disabled={saving || isRunning}>{saving ? '保存中' : '保存字段'}</button>
+            </div>
+            <div className="software-copyright-form-grid">
+              {basicFieldRows.map((field) => (
+                <label className="software-copyright-field" key={field.key}>
+                  <span>{field.label}</span>
+                  <input value={fields[field.key]} placeholder={field.placeholder} onChange={(event) => updateField(field.key, event.target.value)} disabled={isRunning} />
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="software-copyright-panel">
+            <div className="software-copyright-panel-head">
+              <div>
+                <span className="section-kicker">环境与功能</span>
+                <h3>官网填报辅助字段</h3>
+              </div>
+              {missingFields.length > 0 && <span className="software-copyright-warning">有 {missingFields.length} 项建议补全</span>}
+            </div>
+            <div className="software-copyright-form-grid">
+              {environmentFieldRows.map((field) => (
+                <label className="software-copyright-field" key={field.key}>
+                  <span>{field.label}</span>
+                  <input value={fields[field.key]} placeholder={field.placeholder} onChange={(event) => updateField(field.key, event.target.value)} disabled={isRunning} />
+                </label>
+              ))}
+            </div>
+            <label className="software-copyright-field is-wide">
+              <span>软件的主要功能</span>
+              <textarea value={fields.mainFunctions} placeholder="可留空由文本模型根据项目证据生成，建议提交前人工核对。" onChange={(event) => updateField('mainFunctions', event.target.value)} disabled={isRunning} />
+            </label>
+            <label className="software-copyright-field is-wide">
+              <span>软件的技术特点</span>
+              <textarea value={fields.technicalFeatures} placeholder="例如 Electron 桌面应用、AI 文档生成、Markdown/Word 导出等，≤100字符更适合官网字段。" onChange={(event) => updateField('technicalFeatures', event.target.value)} disabled={isRunning} />
+            </label>
+          </section>
+        </main>
+
+        <aside className="software-copyright-side">
+          <section className="software-copyright-panel">
+            <div className="software-copyright-panel-head">
+              <div>
+                <span className="section-kicker">模型</span>
+                <h3>生成设置</h3>
+              </div>
+            </div>
+            <div className={`software-copyright-model-status is-${state?.imageModel.available ? 'available' : 'unavailable'}`}>
+              <strong>生图模型</strong>
+              <span>{state?.imageModel.available ? '已可用' : state?.imageModel.message || '未配置可用'}</span>
+            </div>
+            <label className="software-copyright-toggle">
+              <input
+                type="checkbox"
+                checked={Boolean(state?.options.useAiImages)}
+                onChange={(event) => void handleToggleAiImages(event.target.checked)}
+                disabled={!state?.imageModel.available || isRunning}
+              />
+              <span>生成操作手册示意图</span>
+            </label>
+            <div className="software-copyright-export-options">
+              <strong>正式资料导出项</strong>
+              <span className="software-copyright-export-note">导出材料格式需根据当地受理要求人为微调，请勿直接使用！</span>
+              {exportItemRows.map((item) => (
+                <label className="software-copyright-toggle" key={item.key}>
+                  <input
+                    type="checkbox"
+                    checked={Boolean(exportItems[item.key])}
+                    onChange={(event) => void handleToggleExportItem(item.key, event.target.checked)}
+                    disabled={isRunning}
+                  />
+                  <span>{item.label}</span>
+                </label>
+              ))}
+              {!hasExportItem && <span className="software-copyright-option-warning">至少选择一项后才能导出。</span>}
+            </div>
+          </section>
+
+          <section className="software-copyright-panel">
+            <div className="software-copyright-panel-head">
+              <div>
+                <span className="section-kicker">生成</span>
+                <h3>任务进度</h3>
+              </div>
+              {task && <em className={`software-copyright-task-status is-${task.status}`}>{task.status === 'running' ? '运行中' : task.status === 'success' ? '完成' : '失败'}</em>}
+            </div>
+            <div className="software-copyright-progress" aria-label="生成进度">
+              <span style={{ width: `${Math.max(0, Math.min(100, task?.progress || 0))}%` }} />
+            </div>
+            <div className="software-copyright-step-actions">
+              <button type="button" className="primary-action" onClick={handleGenerateDraft} disabled={!canGenerateDraft}>
+                {isRunning && task?.type === 'software-copyright-draft-generation' ? '生成草稿中...' : '生成草稿'}
+              </button>
+              <button type="button" className="secondary-action" onClick={() => void handleValidateDraft()} disabled={!canValidateDraft || validating}>
+                {validating ? '检查中...' : '检查草稿'}
+              </button>
+              <button type="button" className="secondary-action" onClick={handleConfirmDraft} disabled={!canConfirmDraft}>确认草稿</button>
+              <button type="button" className="primary-action" onClick={handleExportFinal} disabled={!canExportFinal}>
+                {isRunning && task?.type === 'software-copyright-final-export' ? '导出中...' : '导出正式资料'}
+              </button>
+            </div>
+            {validation && (
+              <div className={`software-copyright-validation is-${validation.valid ? 'valid' : 'invalid'}`}>
+                <strong>{validation.valid ? '草稿检查通过' : `草稿检查未通过（${validation.issues.length} 项）`}</strong>
+                {validation.issues.length ? (
+                  <ul>
+                    {validation.issues.map((issue, index) => (
+                      <li key={`${issue.type}-${issue.key || index}-${issue.message}`}>{issue.message}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <span>可以确认草稿并导出正式资料。</span>
+                )}
+              </div>
+            )}
+            {task?.error && (
+              <div className="software-copyright-recovery">
+                <strong>{task.recovery?.title || '任务执行失败'}</strong>
+                <p>{task.recovery?.message || task.error}</p>
+                {task.recovery?.actions?.length ? (
+                  <ul>
+                    {task.recovery.actions.map((action) => <li key={action}>{action}</li>)}
+                  </ul>
+                ) : null}
+              </div>
+            )}
+            <div className="software-copyright-log">
+              {(task?.logs || ['等待生成草稿']).slice(-8).map((log, index) => <span key={`${log}-${index}`}>{log}</span>)}
+            </div>
+          </section>
+
+          <section className="software-copyright-panel">
+            <div className="software-copyright-panel-head">
+              <div>
+                <span className="section-kicker">草稿</span>
+                <h3>待确认资料</h3>
+              </div>
+              <div className="software-copyright-draft-actions">
+                {draftDirty && <span className="software-copyright-warning">未保存</span>}
+                {state?.draftConfirmed && <span className="code-generation-confirmed">已确认</span>}
+              </div>
+            </div>
+            {hasDrafts ? (
+              <div className="software-copyright-draft-workspace">
+                <div className="software-copyright-draft-tabs" aria-label="草稿文件">
+                  {draftEntries.map(([key]) => (
+                    <button
+                      type="button"
+                      className={activeDraftKey === key ? 'is-active' : ''}
+                      onClick={() => handleSelectDraft(key)}
+                      disabled={draftLoading || draftSaving}
+                      key={key}
+                    >
+                      {draftLabel(key)}
+                    </button>
+                  ))}
+                </div>
+                <div className="software-copyright-draft-meta">
+                  <span>{draftFile?.name || '正在读取草稿'}</span>
+                  {draftFile?.updatedAt && <span>{new Date(draftFile.updatedAt).toLocaleString()}</span>}
+                </div>
+                <div className="software-copyright-draft-mode" aria-label="草稿查看方式">
+                  <button type="button" className={draftViewMode === 'edit' ? 'is-active' : ''} onClick={() => setDraftViewMode('edit')}>编辑</button>
+                  <button type="button" className={draftViewMode === 'preview' ? 'is-active' : ''} onClick={() => setDraftViewMode('preview')}>预览</button>
+                </div>
+                {draftLoading ? (
+                  <div className="software-copyright-empty">正在读取草稿内容...</div>
+                ) : draftViewMode === 'edit' ? (
+                  <MarkdownEditor
+                    className="software-copyright-draft-editor"
+                    value={draftContent}
+                    onChange={handleDraftContentChange}
+                    placeholder="草稿内容为空"
+                    disabled={isRunning || draftSaving}
+                  />
+                ) : (
+                  <div className="markdown-viewer software-copyright-draft-preview">
+                    <MarkdownRenderer>{draftContent || '草稿内容为空'}</MarkdownRenderer>
+                  </div>
+                )}
+                <button
+                  type="button"
+                  className="secondary-action software-copyright-draft-save"
+                  onClick={handleSaveDraft}
+                  disabled={!draftDirty || draftSaving || isRunning}
+                >
+                  {draftSaving ? '保存中' : '保存草稿'}
+                </button>
+                <span className="software-copyright-draft-path">{draftFile?.path}</span>
+              </div>
+            ) : (
+              <div className="software-copyright-empty">生成草稿后会显示业务理解、申请表信息、操作手册、代码提取清单和代码材料 Markdown。</div>
+            )}
+          </section>
+
+          <section className="software-copyright-panel">
+            <div className="software-copyright-panel-head">
+              <div>
+                <span className="section-kicker">结果</span>
+                <h3>正式资料</h3>
+              </div>
+            </div>
+            {state?.outputs?.length ? (
+              <div className="software-copyright-output-result">
+                {state.outputDir && (
+                  <button type="button" className="software-copyright-output-dir" onClick={handleOpenOutputDir}>
+                    <strong>输出目录</strong>
+                    <span>{state.outputDir}</span>
+                  </button>
+                )}
+                <div className="software-copyright-output-list">
+                  {state.outputs.map((output) => (
+                    <article key={output.path}>
+                      <strong>{output.name}</strong>
+                      <span>{output.path}</span>
+                    </article>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="software-copyright-empty">确认草稿并导出后，会显示申请表 TXT、操作手册 DOCX、代码材料 DOCX 和生成报告。</div>
+            )}
+          </section>
+        </aside>
+      </div>
+      <Dialog.Root open={complianceNoticeOpen} onOpenChange={setComplianceNoticeOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="content-regenerate-modal" />
+          <Dialog.Content className="software-copyright-compliance-card">
+            <div className="software-copyright-export-confirm-head">
+              <div>
+                <Dialog.Title>软著AI合规提醒</Dialog.Title>
+                <Dialog.Description>
+                  导出材料只是整理辅助，最终申报前仍需人工判断、人工改写和人工复核。
+                </Dialog.Description>
+              </div>
+              <Dialog.Close className="detail-help-close" type="button" aria-label="关闭软著AI合规提醒">×</Dialog.Close>
+            </div>
+
+            <div className="software-copyright-compliance-body">
+              <section>
+                <h3>请先确认创作主导关系</h3>
+                <p>软著保护的是具有人类智力独创性的成果。若代码主要由 AI 自动生成，且没有实质性架构设计、逻辑改写、调试优化和人工集成，不建议直接申报。</p>
+              </section>
+              <section>
+                <h3>材料不要直接提交</h3>
+                <p>申请表信息、功能说明、操作手册和代码材料都需要人工核对。尤其是软件全称、版本号、著作权人、开发完成日期、页眉页脚和源码范围，应与正式申请材料保持一致。</p>
+              </section>
+              <section>
+                <h3>保留开发证据链</h3>
+                <ul>
+                  <li>保留需求文档、架构图、Git 提交记录、调试记录和人工修改对比。</li>
+                  <li>如使用 AI 辅助，留存 prompt、AI 输出、人工改写记录和最终代码差异。</li>
+                  <li>对 AI 片段进行结构性重写、注释完善和业务逻辑校验，避免模板化、同质化代码直接进入申报材料。</li>
+                </ul>
+              </section>
+              <section>
+                <h3>遇到 AI 占比较高时</h3>
+                <p>建议先补充人工设计和改造工作，必要时准备《AI 辅助开发情况说明》及完整证据链。具体受理口径请以版权登记机构最新要求为准。</p>
+              </section>
+            </div>
+
+            <div className="software-copyright-export-confirm-actions">
+              <Dialog.Close className="primary-action" type="button">我已知晓</Dialog.Close>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+      <Dialog.Root open={exportConfirmOpen} onOpenChange={setExportConfirmOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="content-regenerate-modal" />
+          <Dialog.Content className="software-copyright-export-confirm-card">
+            <div className="software-copyright-export-confirm-head">
+              <div>
+                <Dialog.Title>导出前最终检查</Dialog.Title>
+                <Dialog.Description>
+                  请确认申请字段、代码材料和导出项无误后再导出正式资料。
+                </Dialog.Description>
+              </div>
+              <Dialog.Close className="detail-help-close" type="button" aria-label="关闭导出确认">×</Dialog.Close>
+            </div>
+
+            <div className="software-copyright-export-confirm-grid">
+              <article>
+                <span>软件全称</span>
+                <strong>{fields.softwareName || '未填写'}</strong>
+              </article>
+              <article>
+                <span>版本号</span>
+                <strong>{fields.version || '未填写'}</strong>
+              </article>
+              <article>
+                <span>草稿状态</span>
+                <strong>{state?.draftConfirmed ? '已确认' : '未确认'}</strong>
+              </article>
+              <article>
+                <span>代码页数</span>
+                <strong>{codeManifest?.total_pages || fields.pageCount || '未生成'}</strong>
+              </article>
+            </div>
+
+            <div className="software-copyright-export-confirm-section">
+              <strong>导出项目</strong>
+              <div className="software-copyright-export-confirm-tags">
+                {selectedExportLabels.map((label) => <span key={label}>{label}</span>)}
+              </div>
+            </div>
+
+            <div className="software-copyright-export-confirm-section">
+              <strong>检查摘要</strong>
+              <ul>
+                {missingFields.length > 0 && <li>仍有 {missingFields.length} 项建议补全字段。</li>}
+                {!state?.draftConfirmed && <li>草稿尚未确认，请先返回确认草稿。</li>}
+                {codeRiskTips.map((tip) => <li key={tip}>{tip}</li>)}
+                {selectedExportLabels.length === 0 && <li>尚未选择任何导出项目。</li>}
+                {missingFields.length === 0 && state?.draftConfirmed && codeRiskTips.length === 0 && selectedExportLabels.length > 0 && (
+                  <li>当前未发现阻塞导出的检查项，仍建议导出后按当地受理要求人工复核。</li>
+                )}
+              </ul>
+            </div>
+
+            <div className="software-copyright-export-confirm-note">
+              导出材料格式需根据当地受理要求人为微调，请勿直接使用！
+            </div>
+
+            <div className="software-copyright-export-confirm-actions">
+              <Dialog.Close className="secondary-action" type="button">返回修改</Dialog.Close>
+              <button
+                type="button"
+                className="primary-action"
+                onClick={handleConfirmExportFinal}
+                disabled={!canExportFinal}
+              >
+                确认导出
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </div>
+  );
+}
+
+function draftLabel(key: string) {
+  const labels: Record<string, string> = {
+    business: '业务理解',
+    application: '申请表信息',
+    manual: '操作手册',
+    codeManifest: '代码提取清单',
+    manualCheck: '操作手册自检记录',
+  };
+  if (labels[key]) return labels[key];
+  if (key.startsWith('code')) return `代码材料 ${key.replace('code', '')}`;
+  return key;
+}
+
+function formatSelectionStrategy(strategy: string) {
+  const labels: Record<string, string> = {
+    'core-category-score-v1': '核心类别覆盖 + 源码权重排序',
+  };
+  return labels[strategy] || strategy;
+}
+
+export default SoftwareCopyrightPage;

--- a/client/src/features/software-copyright/types.ts
+++ b/client/src/features/software-copyright/types.ts
@@ -1,0 +1,178 @@
+export type SoftwareCopyrightStep = 'setup' | 'generating' | 'draft' | 'exporting' | 'result';
+
+export interface SoftwareCopyrightProject {
+  name: string;
+  path: string;
+}
+
+export interface SoftwareCopyrightAnalysisFile {
+  path: string;
+  extension: string;
+  size: number;
+  line_count: number;
+  category: string;
+}
+
+export interface SoftwareCopyrightAnalysis {
+  projectRoot: string;
+  projectName: string;
+  packageName: string;
+  packageVersion: string;
+  scripts: Record<string, string>;
+  frameworks: string[];
+  languages: string[];
+  fileCount: number;
+  lineCount: number;
+  candidates: SoftwareCopyrightAnalysisFile[];
+  readmeExcerpt: string;
+}
+
+export interface SoftwareCopyrightFields {
+  softwareName: string;
+  shortName: string;
+  version: string;
+  category: string;
+  developmentCompletedDate: string;
+  developmentMode: string;
+  softwareDescription: string;
+  publishStatus: string;
+  firstPublishDate: string;
+  copyrightOwner: string;
+  rightsScope: string;
+  rightsAcquisition: string;
+  developmentHardware: string;
+  runningHardware: string;
+  developmentOs: string;
+  developmentTools: string;
+  runningPlatform: string;
+  runtimeSupport: string;
+  programmingLanguage: string;
+  sourceLineCount: string;
+  developmentPurpose: string;
+  industry: string;
+  mainFunctions: string;
+  technicalFeatures: string;
+  pageCount: string;
+}
+
+export interface SoftwareCopyrightOptions {
+  sourceMode: 'project' | 'code-generation';
+  screenshotMode: 'skip' | 'manual' | 'ai';
+  useAiImages: boolean;
+  codeExcludedPaths: string[];
+  codeIncludedPaths: string[];
+  exportItems: {
+    application: boolean;
+    manual: boolean;
+    code: boolean;
+    report: boolean;
+  };
+}
+
+export interface SoftwareCopyrightTask {
+  task_id: string;
+  type: string;
+  status: 'running' | 'success' | 'error';
+  progress: number;
+  logs: string[];
+  started_at: string;
+  updated_at: string;
+  error?: string;
+  recovery?: {
+    title: string;
+    message: string;
+    actions: string[];
+  };
+}
+
+export interface SoftwareCopyrightOutput {
+  name: string;
+  path: string;
+}
+
+export interface SoftwareCopyrightDraftFile {
+  key: string;
+  name: string;
+  path: string;
+  content: string;
+  updatedAt: string;
+}
+
+export interface SoftwareCopyrightDraftSaveResult extends SoftwareCopyrightDraftFile {
+  state: SoftwareCopyrightState;
+}
+
+export interface SoftwareCopyrightDraftValidationIssue {
+  type: 'field' | 'draft' | 'code';
+  severity: 'error' | 'warning';
+  key?: string;
+  message: string;
+}
+
+export interface SoftwareCopyrightDraftValidationResult {
+  valid: boolean;
+  issues: SoftwareCopyrightDraftValidationIssue[];
+  checkedAt: string;
+}
+
+export interface SoftwareCopyrightCodeManifestFile {
+  path: string;
+  category: string;
+  selection_score?: number;
+  source_line_count: number;
+  material_line_start: number;
+  material_line_end: number;
+}
+
+export interface SoftwareCopyrightCodeManifest {
+  software_name: string;
+  version: string;
+  project_root: string;
+  lines_per_page: number;
+  total_pages: number;
+  mode: 'front30_back30' | 'all_under_60_pages' | string;
+  material_line_count: number;
+  selection_strategy?: string;
+  excluded_paths?: string[];
+  included_paths?: string[];
+  category_summary?: Record<string, number>;
+  files: SoftwareCopyrightCodeManifestFile[];
+}
+
+export interface SoftwareCopyrightState {
+  step: SoftwareCopyrightStep;
+  project: SoftwareCopyrightProject | null;
+  analysis: SoftwareCopyrightAnalysis | null;
+  fields: SoftwareCopyrightFields;
+  options: SoftwareCopyrightOptions;
+  imageModel: {
+    available: boolean;
+    status: string;
+    message: string;
+  };
+  codeGeneration?: {
+    available: boolean;
+    project: { name: string; path: string } | null;
+    confirmedAt: string;
+    summary: {
+      selectedCount: number;
+      selectedLineCount: number;
+      estimatedPages: number;
+    } | null;
+  };
+  task?: SoftwareCopyrightTask;
+  drafts: Record<string, string>;
+  draftConfirmed: boolean;
+  draftConfirmedAt?: string;
+  draftDir?: string;
+  outputRoot?: string;
+  outputs: SoftwareCopyrightOutput[];
+  outputDir?: string;
+  updated_at: string;
+}
+
+export interface SoftwareCopyrightSelectResult {
+  success: boolean;
+  message?: string;
+  state: SoftwareCopyrightState;
+}

--- a/client/src/shared/types/index.ts
+++ b/client/src/shared/types/index.ts
@@ -1,5 +1,13 @@
 export type { ChatCompletionRequest, ChatMessage, JsonCompletionRequest } from './ai';
 export type {
+  CodeGenerationAnalysis,
+  CodeGenerationFile,
+  CodeGenerationProject,
+  CodeGenerationSelectResult,
+  CodeGenerationState,
+  CodeGenerationSummary,
+} from '../../features/code-generation/types';
+export type {
   DuplicateAnalysisTabId,
   DuplicateAnalysisStatus,
   DuplicateCheckStep,
@@ -45,9 +53,21 @@ export type {
   TextModelProvider,
   TextModelProfiles,
 } from './config';
-export type { AppMenuItem, SectionId } from './navigation';
+export type { AppMenuGroup, AppMenuItem, SectionId } from './navigation';
 export type { OutlineData, OutlineItem, OutlineMode, TechnicalRequirementGroup } from './outline';
 export type { LatestReleaseInfo, UpdateCheckResult, WordExportProgressEvent, WordExportResult, YuDuBidBridge } from './ipc';
+export type {
+  SoftwareCopyrightAnalysis,
+  SoftwareCopyrightAnalysisFile,
+  SoftwareCopyrightFields,
+  SoftwareCopyrightOptions,
+  SoftwareCopyrightOutput,
+  SoftwareCopyrightProject,
+  SoftwareCopyrightSelectResult,
+  SoftwareCopyrightState,
+  SoftwareCopyrightStep,
+  SoftwareCopyrightTask,
+} from '../../features/software-copyright/types';
 export type {
   RejectionCheckFinding,
   RejectionCheckResultState,

--- a/client/src/shared/types/ipc.ts
+++ b/client/src/shared/types/ipc.ts
@@ -1,8 +1,10 @@
 import type { ChatCompletionRequest, JsonCompletionRequest } from './ai';
 import type { DuplicateCheckWorkspaceState, FileSelectionResult } from './bid';
 import type { ClientConfig, ConfigSaveResult, ImageModelTestResult, ModelListResult } from './config';
+import type { CodeGenerationSelectResult, CodeGenerationState } from '../../features/code-generation/types';
 import type { KnowledgeAnalysisSnapshot, KnowledgeBaseEvent, KnowledgeBaseIndex, KnowledgeBaseMigrationResult, KnowledgeBaseMigrationStatus, KnowledgeBaseMutationResult, KnowledgeBaseStartMatchingResult, KnowledgeBaseUploadResult, KnowledgeDocument, KnowledgeFolder, KnowledgeItem } from '../../features/knowledge-base/types';
 import type { RejectionCheckWorkspaceState, RejectionDocumentRole } from '../../features/rejection-check/types';
+import type { SoftwareCopyrightCodeManifest, SoftwareCopyrightDraftFile, SoftwareCopyrightDraftSaveResult, SoftwareCopyrightDraftValidationResult, SoftwareCopyrightFields, SoftwareCopyrightOptions, SoftwareCopyrightSelectResult, SoftwareCopyrightState } from '../../features/software-copyright/types';
 import type { BidAnalysisTaskState, ContentGenerationOptions, ContentGenerationPlanState, ContentGenerationRuntimeState, ContentGenerationSectionState, GlobalFactGroupState, TechnicalPlanState, TechnicalPlanStep } from '../../features/technical-plan/types';
 import type { OutlineData, OutlineMode } from './outline';
 
@@ -87,6 +89,13 @@ export interface YuDuBidBridge {
   file: {
     selectDuplicateCheckFiles: (options?: { multiple?: boolean }) => Promise<FileSelectionResult>;
   };
+  codeGeneration: {
+    loadState: () => Promise<CodeGenerationState>;
+    selectProject: () => Promise<CodeGenerationSelectResult>;
+    updateSelection: (payload: { selectedPaths: string[] }) => Promise<CodeGenerationState>;
+    confirmSelection: () => Promise<CodeGenerationState>;
+    clear: () => Promise<{ success: boolean; state: CodeGenerationState }>;
+  };
   knowledgeBase: {
     getMigrationStatus: () => Promise<KnowledgeBaseMigrationStatus>;
     migrateLegacy: () => Promise<KnowledgeBaseMigrationResult>;
@@ -129,6 +138,23 @@ export interface YuDuBidBridge {
     saveUiState: (payload: Partial<Pick<RejectionCheckWorkspaceState, 'step' | 'activeDocumentTab' | 'activeResultTab' | 'activeCheckResultTab' | 'customCheckItems' | 'checkOptions'>>) => Promise<RejectionCheckWorkspaceState>;
     updateState: (partial: Partial<RejectionCheckWorkspaceState>) => Promise<RejectionCheckWorkspaceState>;
     clear: () => Promise<{ success: boolean; message?: string; state: RejectionCheckWorkspaceState }>;
+  };
+  softwareCopyright: {
+    loadState: () => Promise<SoftwareCopyrightState>;
+    selectProject: () => Promise<SoftwareCopyrightSelectResult>;
+    saveFields: (fields: Partial<SoftwareCopyrightFields>) => Promise<SoftwareCopyrightState>;
+    saveOptions: (options: Partial<SoftwareCopyrightOptions>) => Promise<SoftwareCopyrightState>;
+    readDraft: (draftKey: string) => Promise<SoftwareCopyrightDraftFile>;
+    readCodeManifest: () => Promise<SoftwareCopyrightCodeManifest | null>;
+    regenerateCodeMaterial: (payload?: { fields?: Partial<SoftwareCopyrightFields>; sourceMode?: 'project' | 'code-generation'; codeExcludedPaths?: string[]; codeIncludedPaths?: string[] }) => Promise<{ state: SoftwareCopyrightState; manifest: SoftwareCopyrightCodeManifest }>;
+    saveDraft: (payload: { key: string; content: string }) => Promise<SoftwareCopyrightDraftSaveResult>;
+    validateDraft: () => Promise<SoftwareCopyrightDraftValidationResult>;
+    startGeneration: (payload?: { fields?: Partial<SoftwareCopyrightFields>; useAiImages?: boolean; sourceMode?: 'project' | 'code-generation'; codeExcludedPaths?: string[]; codeIncludedPaths?: string[] }) => Promise<unknown>;
+    confirmDraft: () => Promise<SoftwareCopyrightState>;
+    exportFinal: (payload?: { exportItems?: SoftwareCopyrightOptions['exportItems'] }) => Promise<unknown>;
+    clear: () => Promise<{ success: boolean; message?: string; state: SoftwareCopyrightState }>;
+    openOutputDir: () => Promise<{ success: boolean; path: string }>;
+    onEvent: (callback: (event: SoftwareCopyrightState) => void) => () => void;
   };
   tasks: {
     startBidAnalysis: (payload: unknown) => Promise<unknown>;

--- a/client/src/shared/types/navigation.ts
+++ b/client/src/shared/types/navigation.ts
@@ -1,6 +1,8 @@
 export type SectionId =
   | 'technical-plan'
   | 'business-bid'
+  | 'code-generation'
+  | 'software-copyright'
   | 'knowledge-base'
   | 'duplicate-check'
   | 'rejection-check'
@@ -12,4 +14,10 @@ export interface AppMenuItem {
   id: SectionId;
   label: string;
   description: string;
+}
+
+export interface AppMenuGroup {
+  id: string;
+  label: string;
+  items: AppMenuItem[];
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -49,6 +49,1539 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+.software-copyright-page {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  padding: 24px;
+}
+
+.software-copyright-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 22px 24px;
+  border: 1px solid rgba(27, 50, 92, 0.1);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.06);
+}
+
+.software-copyright-header h2 {
+  margin: 6px 0 8px;
+  color: #172033;
+  font-size: 22px;
+  line-height: 1.25;
+}
+
+.software-copyright-header p {
+  max-width: 760px;
+  margin: 0;
+  color: #627089;
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.software-copyright-format-notice {
+  max-width: 820px;
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid rgba(34, 99, 235, 0.14);
+  border-radius: 12px;
+  background: #f0f7ff;
+  color: #315174;
+  font-size: 13px;
+  font-weight: 800;
+  line-height: 1.6;
+}
+
+.software-copyright-compliance-link {
+  margin-top: 10px;
+  padding: 8px 12px;
+  border: 1px solid rgba(37, 99, 235, 0.14);
+  border-radius: 999px;
+  background: #fff;
+  color: #1d4ed8;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.software-copyright-compliance-link:hover {
+  border-color: rgba(37, 99, 235, 0.28);
+  background: #f0f7ff;
+  transform: translateY(-1px);
+}
+
+.software-copyright-header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.software-copyright-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  gap: 18px;
+  min-height: 0;
+  flex: 1;
+}
+
+.software-copyright-main,
+.software-copyright-side {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-height: 0;
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.software-copyright-panel {
+  padding: 20px;
+  border: 1px solid rgba(27, 50, 92, 0.1);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+}
+
+.software-copyright-panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+
+.software-copyright-panel-head h3 {
+  margin: 5px 0 0;
+  color: #172033;
+  font-size: 17px;
+  line-height: 1.3;
+}
+
+.software-copyright-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.software-copyright-stats article {
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.software-copyright-stats span,
+.software-copyright-output-list span,
+.software-copyright-model-status span,
+.software-copyright-log span {
+  color: #65738c;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.software-copyright-stats strong {
+  display: block;
+  margin-top: 6px;
+  color: #172033;
+  font-size: 18px;
+  line-height: 1.3;
+}
+
+.software-copyright-stats article.is-text strong {
+  display: -webkit-box;
+  overflow: hidden;
+  font-size: 15px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.software-copyright-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.software-copyright-field {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 7px;
+  color: #314059;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.software-copyright-field.is-wide {
+  margin-top: 14px;
+}
+
+.software-copyright-field input,
+.software-copyright-field textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid rgba(27, 50, 92, 0.14);
+  border-radius: 10px;
+  background: #fff;
+  color: #172033;
+  font: inherit;
+  font-weight: 500;
+}
+
+.software-copyright-field input {
+  height: 40px;
+  padding: 0 12px;
+}
+
+.software-copyright-field textarea {
+  min-height: 96px;
+  resize: vertical;
+  padding: 11px 12px;
+  line-height: 1.65;
+}
+
+.software-copyright-field input:focus,
+.software-copyright-field textarea:focus {
+  border-color: rgba(34, 99, 235, 0.5);
+  box-shadow: 0 0 0 3px rgba(34, 99, 235, 0.1);
+  outline: none;
+}
+
+.software-copyright-empty {
+  padding: 18px;
+  border: 1px dashed rgba(27, 50, 92, 0.18);
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #64748b;
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.software-copyright-source-switch {
+  display: inline-flex;
+  gap: 6px;
+  margin-bottom: 16px;
+  padding: 4px;
+  border: 1px solid rgba(27, 50, 92, 0.1);
+  border-radius: 999px;
+  background: #f8fafc;
+}
+
+.software-copyright-source-switch button {
+  min-height: 34px;
+  border: 0;
+  border-radius: 999px;
+  padding: 0 14px;
+  color: #64748b;
+  background: transparent;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.software-copyright-source-switch button.is-active {
+  color: #fff;
+  background: var(--yb-action-gradient);
+}
+
+.software-copyright-source-switch button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.software-copyright-warning,
+.software-copyright-task-status {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 700;
+}
+
+.software-copyright-warning {
+  background: #fff7ed;
+  color: #c2410c;
+}
+
+.software-copyright-task-status.is-running {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.software-copyright-task-status.is-success {
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.software-copyright-task-status.is-error {
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.software-copyright-model-status {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.software-copyright-model-status strong {
+  color: #172033;
+  font-size: 14px;
+}
+
+.software-copyright-model-status.is-available {
+  border: 1px solid rgba(4, 120, 87, 0.18);
+  background: #ecfdf5;
+}
+
+.software-copyright-model-status.is-unavailable {
+  border: 1px solid rgba(203, 91, 31, 0.16);
+  background: #fff7ed;
+}
+
+.software-copyright-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 14px;
+  color: #314059;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.software-copyright-export-options {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(27, 50, 92, 0.08);
+}
+
+.software-copyright-export-options > strong {
+  margin-bottom: 2px;
+  color: #172033;
+  font-size: 14px;
+}
+
+.software-copyright-export-note {
+  margin: 4px 0 6px;
+  color: #526b8b;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.software-copyright-export-options .software-copyright-toggle {
+  margin-top: 8px;
+}
+
+.software-copyright-option-warning {
+  margin-top: 8px;
+  color: #c2410c;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.software-copyright-progress {
+  height: 9px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e2e8f0;
+}
+
+.software-copyright-progress span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: #2563eb;
+  transition: width 0.2s ease;
+}
+
+.software-copyright-step-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.software-copyright-step-actions button {
+  min-width: 0;
+  padding-inline: 12px;
+}
+
+.software-copyright-validation {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 12px;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.software-copyright-validation.is-valid {
+  border: 1px solid rgba(4, 120, 87, 0.16);
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.software-copyright-validation.is-invalid {
+  border: 1px solid rgba(185, 28, 28, 0.12);
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.software-copyright-validation strong {
+  color: inherit;
+  font-size: 13px;
+}
+
+.software-copyright-validation ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.software-copyright-validation li + li {
+  margin-top: 4px;
+}
+
+.software-copyright-generate {
+  width: 100%;
+  margin-top: 14px;
+}
+
+.software-copyright-error {
+  margin: 12px 0 0;
+  color: #b91c1c;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.software-copyright-recovery {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 14px;
+  padding: 13px;
+  border: 1px solid rgba(185, 28, 28, 0.12);
+  border-radius: 12px;
+  background: #fef2f2;
+  color: #991b1b;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.software-copyright-recovery strong {
+  color: inherit;
+  font-size: 14px;
+}
+
+.software-copyright-recovery p {
+  margin: 0;
+}
+
+.software-copyright-recovery ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.software-copyright-recovery li + li {
+  margin-top: 4px;
+}
+
+.software-copyright-log {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 190px;
+  margin-top: 14px;
+  overflow: auto;
+  padding: 12px;
+  border-radius: 12px;
+  background: #0f172a;
+}
+
+.software-copyright-log span {
+  color: #dbeafe;
+}
+
+.software-copyright-code-manifest {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.software-copyright-code-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.software-copyright-code-actions .secondary-action {
+  min-height: 34px;
+  padding: 0 12px;
+  font-size: 13px;
+}
+
+.software-copyright-code-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.software-copyright-code-summary article {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+.software-copyright-code-summary span,
+.software-copyright-code-strategy span,
+.software-copyright-code-more {
+  color: #65738c;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.software-copyright-code-summary strong {
+  display: block;
+  margin-top: 4px;
+  color: #172033;
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+.software-copyright-code-status {
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.software-copyright-code-status.is-ready {
+  border: 1px solid rgba(4, 120, 87, 0.16);
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.software-copyright-code-status.is-review {
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.software-copyright-code-risk {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 11px 12px;
+  border: 1px solid rgba(37, 99, 235, 0.14);
+  border-radius: 10px;
+  background: #f8fbff;
+  color: #314059;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.software-copyright-code-risk strong {
+  color: #1d4ed8;
+  font-size: 13px;
+}
+
+.software-copyright-code-risk ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.software-copyright-code-risk li + li {
+  margin-top: 5px;
+}
+
+.software-copyright-code-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.software-copyright-code-tags span {
+  padding: 5px 9px;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 999px;
+  background: #fff;
+  color: #314059;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.software-copyright-code-strategy {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+.software-copyright-code-strategy strong {
+  flex: 0 0 auto;
+  color: #172033;
+  font-size: 13px;
+}
+
+.software-copyright-code-strategy span {
+  min-width: 0;
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.software-copyright-code-excluded {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid rgba(37, 99, 235, 0.14);
+  border-radius: 10px;
+  background: #eff6ff;
+}
+
+.software-copyright-code-excluded strong {
+  color: #1d4ed8;
+  font-size: 13px;
+}
+
+.software-copyright-code-excluded div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.software-copyright-code-excluded button {
+  max-width: 100%;
+  overflow: hidden;
+  padding: 5px 9px;
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  border-radius: 999px;
+  background: #fff;
+  color: #314059;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.software-copyright-code-excluded button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.software-copyright-code-picker {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 9px;
+  padding: 10px 12px;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+.software-copyright-code-picker-head {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+}
+
+.software-copyright-code-picker-head strong {
+  color: #172033;
+  font-size: 13px;
+}
+
+.software-copyright-code-picker-head input {
+  min-width: 0;
+  height: 32px;
+  border: 1px solid rgba(27, 50, 92, 0.12);
+  border-radius: 9px;
+  background: #fff;
+  color: #172033;
+  font: inherit;
+  font-size: 12px;
+  padding: 0 10px;
+}
+
+.software-copyright-code-included {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.software-copyright-code-included button {
+  max-width: 100%;
+  overflow: hidden;
+  padding: 5px 9px;
+  border: 1px solid rgba(4, 120, 87, 0.16);
+  border-radius: 999px;
+  background: #ecfdf5;
+  color: #047857;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.software-copyright-code-candidates {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 190px;
+  overflow: auto;
+}
+
+.software-copyright-code-candidates button {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 7px 9px;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 9px;
+  background: #fff;
+  color: #314059;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.software-copyright-code-candidates button:hover {
+  border-color: rgba(37, 99, 235, 0.24);
+  background: #eff6ff;
+}
+
+.software-copyright-code-candidates button:disabled,
+.software-copyright-code-included button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.software-copyright-code-candidates span {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.software-copyright-code-candidates > span {
+  color: #65738c;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.software-copyright-code-candidates em {
+  color: #65738c;
+  font-size: 11px;
+  font-style: normal;
+  white-space: nowrap;
+}
+
+.software-copyright-code-table {
+  overflow: hidden;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.software-copyright-code-row {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) 72px 52px;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 10px;
+  color: #314059;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.software-copyright-code-row + .software-copyright-code-row {
+  border-top: 1px solid rgba(27, 50, 92, 0.07);
+}
+
+.software-copyright-code-row.is-head {
+  background: #f8fafc;
+  color: #65738c;
+  font-weight: 700;
+}
+
+.software-copyright-code-row.is-excluded {
+  background: #f8fafc;
+  color: #94a3b8;
+}
+
+.software-copyright-code-row span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.software-copyright-code-row span:last-child {
+  text-align: right;
+}
+
+.software-copyright-code-exclude-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.software-copyright-code-exclude-check input {
+  width: 16px;
+  height: 16px;
+  accent-color: #2563eb;
+}
+
+.software-copyright-output-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.software-copyright-export-confirm-card {
+  position: fixed;
+  z-index: 101;
+  top: 50%;
+  left: 50%;
+  width: min(720px, calc(100vw - 40px));
+  max-height: min(760px, calc(100vh - 40px));
+  overflow: auto;
+  padding: 24px;
+  border: 1px solid rgba(27, 50, 92, 0.12);
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.22);
+  transform: translate(-50%, -50%);
+}
+
+.software-copyright-export-confirm-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.software-copyright-export-confirm-head h2 {
+  margin: 0;
+  color: #172033;
+  font-size: 20px;
+  line-height: 1.3;
+}
+
+.software-copyright-export-confirm-head p {
+  margin: 6px 0 0;
+  color: #65738c;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.software-copyright-export-confirm-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.software-copyright-export-confirm-grid article {
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+.software-copyright-export-confirm-grid span {
+  display: block;
+  color: #65738c;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.software-copyright-export-confirm-grid strong {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  margin-top: 6px;
+  color: #172033;
+  font-size: 14px;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.software-copyright-export-confirm-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 13px;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 12px;
+  background: #fff;
+}
+
+.software-copyright-export-confirm-section > strong {
+  color: #172033;
+  font-size: 14px;
+}
+
+.software-copyright-export-confirm-section ul {
+  margin: 0;
+  padding-left: 18px;
+  color: #314059;
+  font-size: 13px;
+  line-height: 1.65;
+}
+
+.software-copyright-export-confirm-section li + li {
+  margin-top: 5px;
+}
+
+.software-copyright-export-confirm-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.software-copyright-export-confirm-tags span {
+  padding: 6px 10px;
+  border: 1px solid rgba(37, 99, 235, 0.14);
+  border-radius: 999px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.software-copyright-export-confirm-note {
+  margin-top: 14px;
+  padding: 11px 12px;
+  border: 1px solid rgba(37, 99, 235, 0.14);
+  border-radius: 10px;
+  background: #f8fbff;
+  color: #1d4ed8;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.6;
+}
+
+.software-copyright-export-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.software-copyright-compliance-card {
+  position: fixed;
+  z-index: 101;
+  top: 50%;
+  left: 50%;
+  width: min(680px, calc(100vw - 40px));
+  max-height: min(760px, calc(100vh - 40px));
+  overflow: auto;
+  padding: 24px;
+  border: 1px solid rgba(27, 50, 92, 0.12);
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.22);
+  transform: translate(-50%, -50%);
+}
+
+.software-copyright-compliance-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.software-copyright-compliance-body section {
+  padding: 14px;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 13px;
+  background: #f8fbff;
+}
+
+.software-copyright-compliance-body h3 {
+  margin: 0 0 8px;
+  color: #1d4ed8;
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+.software-copyright-compliance-body p,
+.software-copyright-compliance-body ul {
+  margin: 0;
+  color: #314059;
+  font-size: 13px;
+  line-height: 1.75;
+}
+
+.software-copyright-compliance-body ul {
+  padding-left: 20px;
+}
+
+.software-copyright-compliance-body li + li {
+  margin-top: 5px;
+}
+
+.software-copyright-output-result {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.software-copyright-output-dir {
+  width: 100%;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid rgba(34, 99, 235, 0.18);
+  border-radius: 12px;
+  background: rgba(34, 99, 235, 0.06);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.software-copyright-output-dir:hover {
+  border-color: rgba(34, 99, 235, 0.34);
+  background: rgba(34, 99, 235, 0.1);
+}
+
+.software-copyright-output-dir strong {
+  display: block;
+  margin-bottom: 5px;
+  color: #2263eb;
+  font-size: 13px;
+}
+
+.software-copyright-output-dir span {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.software-copyright-output-list article {
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.software-copyright-output-list strong {
+  display: block;
+  margin-bottom: 5px;
+  overflow-wrap: anywhere;
+  color: #172033;
+  font-size: 13px;
+}
+
+.software-copyright-output-list span {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.software-copyright-draft-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.software-copyright-draft-workspace {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.software-copyright-draft-tabs {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 3px;
+}
+
+.software-copyright-draft-tabs button,
+.software-copyright-draft-mode button {
+  border: 1px solid rgba(33, 116, 253, 0.14);
+  border-radius: 999px;
+  background: #f8fbff;
+  color: #52627a;
+  font-size: 13px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.software-copyright-draft-tabs button {
+  padding: 8px 12px;
+}
+
+.software-copyright-draft-tabs button.is-active,
+.software-copyright-draft-mode button.is-active {
+  border-color: transparent;
+  background: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 10px 22px rgba(37, 99, 235, 0.18);
+}
+
+.software-copyright-draft-tabs button:disabled,
+.software-copyright-draft-mode button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.software-copyright-draft-meta {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  color: #66758e;
+  font-size: 12px;
+}
+
+.software-copyright-draft-meta span {
+  overflow-wrap: anywhere;
+}
+
+.software-copyright-draft-mode {
+  display: inline-flex;
+  width: fit-content;
+  gap: 6px;
+  padding: 4px;
+  border-radius: 999px;
+  background: #edf4ff;
+}
+
+.software-copyright-draft-mode button {
+  padding: 6px 12px;
+}
+
+.software-copyright-draft-editor {
+  min-height: 360px;
+}
+
+.software-copyright-draft-editor .markdown-editor-textarea {
+  min-height: 300px;
+  resize: vertical;
+}
+
+.software-copyright-draft-preview {
+  min-height: 360px;
+  max-height: 520px;
+  overflow: auto;
+  padding: 16px;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 14px;
+  background: #ffffff;
+}
+
+.software-copyright-draft-save {
+  align-self: flex-start;
+}
+
+.software-copyright-draft-path {
+  overflow-wrap: anywhere;
+  color: #8390a5;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.code-generation-preview-card {
+  display: flex;
+  min-width: 260px;
+  flex-direction: column;
+  gap: 10px;
+  padding: 22px;
+  border: 1px solid rgba(33, 116, 253, 0.14);
+  border-radius: 18px;
+  background: #f8fbff;
+}
+
+.code-generation-preview-card span,
+.code-generation-preview-card small {
+  color: #66758e;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.code-generation-preview-card strong {
+  color: #172033;
+  font-size: 30px;
+  line-height: 1.1;
+}
+
+.code-generation-page {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  padding: 24px;
+}
+
+.code-generation-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 22px 24px;
+  border: 1px solid rgba(27, 50, 92, 0.1);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.06);
+}
+
+.code-generation-header h2 {
+  margin: 6px 0 8px;
+  color: #172033;
+  font-size: 22px;
+  line-height: 1.25;
+}
+
+.code-generation-header p {
+  max-width: 760px;
+  margin: 0;
+  color: #627089;
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.code-generation-notice-link {
+  margin-top: 12px;
+  padding: 9px 13px;
+  border: 1px solid rgba(37, 99, 235, 0.14);
+  border-radius: 999px;
+  background: #f0f7ff;
+  color: #1d4ed8;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.code-generation-notice-link:hover {
+  border-color: rgba(37, 99, 235, 0.28);
+  background: #eaf2ff;
+  transform: translateY(-1px);
+}
+
+.code-generation-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 18px;
+  min-height: 0;
+  flex: 1;
+}
+
+.code-generation-main,
+.code-generation-side {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: 18px;
+  overflow: auto;
+}
+
+.code-generation-confirmed {
+  border-radius: 999px;
+  padding: 6px 10px;
+  color: #047857;
+  background: #ecfdf5;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.code-generation-files-panel {
+  min-height: 0;
+  flex: 1;
+}
+
+.code-generation-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.code-generation-filter button {
+  border: 1px solid rgba(27, 50, 92, 0.1);
+  border-radius: 999px;
+  padding: 8px 12px;
+  color: #64748b;
+  background: #f8fafc;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.code-generation-filter button.is-active {
+  color: #fff;
+  background: var(--yb-action-gradient);
+  border-color: transparent;
+}
+
+.code-generation-file-list {
+  display: flex;
+  max-height: 520px;
+  flex-direction: column;
+  gap: 8px;
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.code-generation-file-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  padding: 12px;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.code-generation-file-row input {
+  width: 16px;
+  height: 16px;
+}
+
+.code-generation-file-main {
+  min-width: 0;
+}
+
+.code-generation-file-main strong,
+.code-generation-file-main small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.code-generation-file-main strong {
+  color: #172033;
+  font-size: 13px;
+}
+
+.code-generation-file-main small {
+  margin-top: 4px;
+  color: #64748b;
+  font-size: 12px;
+}
+
+.code-generation-flow {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.code-generation-flow span {
+  padding: 12px;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #314059;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.code-generation-side p {
+  margin: 14px 0 0;
+  color: #64748b;
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.code-generation-ai-notice-card {
+  position: fixed;
+  z-index: 101;
+  top: 50%;
+  left: 50%;
+  display: flex;
+  width: min(860px, calc(100vw - 40px));
+  max-height: min(820px, calc(100vh - 40px));
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid rgba(27, 50, 92, 0.12);
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.22);
+  transform: translate(-50%, -50%);
+}
+
+.code-generation-ai-notice-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 22px 24px 16px;
+  border-bottom: 1px solid rgba(27, 50, 92, 0.08);
+  background: #f8fbff;
+}
+
+.code-generation-ai-notice-head h2 {
+  margin: 0;
+  color: #172033;
+  font-size: 21px;
+  line-height: 1.35;
+}
+
+.code-generation-ai-notice-head p {
+  max-width: 700px;
+  margin: 7px 0 0;
+  color: #5f6f87;
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.code-generation-ai-notice-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  gap: 14px;
+  overflow: auto;
+  padding: 18px 24px 22px;
+}
+
+.code-generation-ai-notice-body section {
+  padding: 16px;
+  border: 1px solid rgba(27, 50, 92, 0.08);
+  border-radius: 14px;
+  background: #fff;
+}
+
+.code-generation-ai-notice-body h3 {
+  margin: 0 0 12px;
+  color: #1d4ed8;
+  font-size: 16px;
+  line-height: 1.45;
+}
+
+.code-generation-ai-notice-block + .code-generation-ai-notice-block {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px dashed rgba(27, 50, 92, 0.12);
+}
+
+.code-generation-ai-notice-block h4 {
+  margin: 0 0 8px;
+  color: #172033;
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.code-generation-ai-notice-block p {
+  margin: 0 0 8px;
+  color: #314059;
+  font-size: 13px;
+  line-height: 1.75;
+}
+
+.code-generation-ai-notice-block ul {
+  margin: 0;
+  padding-left: 20px;
+  color: #314059;
+  font-size: 13px;
+  line-height: 1.75;
+}
+
+.code-generation-ai-notice-block li + li {
+  margin-top: 5px;
+}
+
+.code-generation-ai-notice-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 14px 24px 20px;
+  border-top: 1px solid rgba(27, 50, 92, 0.08);
+  background: #fff;
+}
+
+@media (max-width: 1180px) {
+  .software-copyright-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .software-copyright-side {
+    overflow: visible;
+  }
+
+  .code-generation-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .code-generation-side {
+    overflow: visible;
+  }
+}
+
+@media (max-width: 820px) {
+  .software-copyright-page {
+    overflow: auto;
+    padding: 16px;
+  }
+
+  .code-generation-page {
+    overflow: auto;
+    padding: 16px;
+  }
+
+  .software-copyright-header,
+  .code-generation-header,
+  .software-copyright-panel-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .software-copyright-header-actions {
+    justify-content: flex-start;
+  }
+
+  .software-copyright-form-grid,
+  .software-copyright-stats {
+    grid-template-columns: 1fr;
+  }
+}
+
 :root[data-ui-theme="aurora"] {
   --yb-primary: #8d5cf6;
   --yb-primary-hover: #a76ff8;
@@ -359,18 +1892,115 @@ button {
   transform: rotate(180deg);
 }
 
+.rotate-90 {
+  transform: rotate(90deg);
+}
+
+.rotate-270 {
+  transform: rotate(270deg);
+}
+
 .sidebar-nav {
   display: flex;
   flex: 1;
   flex-direction: column;
-  gap: 8px;
+  gap: 18px;
+  min-height: 0;
   margin-top: 34px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 4px;
+  scrollbar-color: rgba(33, 116, 253, 0.28) transparent;
+  scrollbar-width: thin;
+  -webkit-app-region: no-drag;
+}
+
+.sidebar-nav::-webkit-scrollbar {
+  width: 7px;
+}
+
+.sidebar-nav::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.sidebar-nav::-webkit-scrollbar-thumb {
+  background: rgba(33, 116, 253, 0.22);
+  border-radius: 999px;
+}
+
+.sidebar-nav::-webkit-scrollbar-thumb:hover {
+  background: rgba(33, 116, 253, 0.38);
 }
 
 .is-collapsed .sidebar-nav {
   width: 100%;
   align-items: center;
+  gap: 14px;
+  padding-right: 0;
+}
+
+.nav-group {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.nav-group-trigger {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
   gap: 10px;
+  padding: 12px;
+  color: var(--yb-text-soft);
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 18px;
+  -webkit-app-region: no-drag;
+}
+
+.nav-group-trigger:hover {
+  color: var(--yb-primary);
+  background: rgba(33, 116, 253, 0.06);
+  border-color: rgba(33, 116, 253, 0.12);
+}
+
+.nav-group.has-active > .nav-group-trigger {
+  color: var(--yb-primary);
+  background: rgba(33, 116, 253, 0.06);
+}
+
+.nav-group-trigger span {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 15px;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nav-group-trigger svg {
+  width: 17px;
+  height: 17px;
+  flex: 0 0 17px;
+  transition: transform 160ms ease;
+}
+
+.nav-group-items {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 8px;
+  padding-left: 12px;
+}
+
+.is-collapsed .nav-group,
+.is-collapsed .nav-group-items {
+  align-items: center;
+  padding-left: 0;
 }
 
 .nav-item,
@@ -854,6 +2484,12 @@ button {
   background: rgba(200, 50, 32, 0.08);
   border: 1px solid rgba(200, 50, 32, 0.16);
   border-radius: 999px;
+}
+
+.danger-action:hover:not(:disabled) {
+  color: #b42318;
+  background: rgba(200, 50, 32, 0.12);
+  border-color: rgba(200, 50, 32, 0.24);
 }
 
 .primary-action:disabled,
@@ -9053,6 +10689,20 @@ button {
     gap: 8px;
     margin: 0;
     overflow-x: auto;
+    overflow-y: hidden;
+    padding-right: 0;
+  }
+
+  .nav-group,
+  .nav-group-items {
+    width: auto;
+    flex-direction: row;
+    gap: 8px;
+    padding-left: 0;
+  }
+
+  .nav-group-trigger {
+    display: none;
   }
 
   .sidebar-footer {


### PR DESCRIPTION
## 变更内容

- 增加左侧一级/二级折叠导航结构，补齐软件著作分组与代码生成入口。
- 增加代码材料准备能力，支持项目源码扫描、技术栈统计、核心文件筛选与预览。
- 增加软著生成流程，覆盖申请表信息、操作手册、代码材料、生成报告与导出说明。
- 增加 AI 软著合规提示弹窗、导出格式温馨提醒、导出路径展示与目录打开能力。
- 增加软著生成验证脚本，便于用真实项目目录做端到端材料生成检查。

## 验证

- node --check electron/services/softwareCopyrightService.cjs electron/services/codeGenerationService.cjs electron/ipc/softwareCopyrightIpc.cjs electron/ipc/codeGenerationIpc.cjs electron/preload.cjs scripts/verify-software-copyright.cjs
- npm run build
- SOFTWARE_COPYRIGHT_VERIFY_PROJECT=/Users/liwugang/codes/resume npm run verify:software-copyright

## 备注

- 构建中仅出现既有 Vite chunk 体积提示，命令退出码为 0。
- 导出的软著材料仍需根据当地受理要求人工微调后使用。
